### PR TITLE
BBBSL-12: Added config.hosts and secrets.yml for produciton

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,4 +36,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts << ENV['URL_HOST'] || ''
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,4 +87,6 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.hosts << ENV['URL_HOST'] || ''
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rails secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: 659e7f714d268bc2a68a6b447d9a4deca0a01032e54dfc449b489dc36108bdf5
+
+test:
+  secret_key_base: 8f27b340be49500672e72257637ddb7fee41b7900f0fceb48ac2503b15de7540
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
This is the first cut for BBBSL-12, just to make work the docker images as for production.

Tested with docker-compose using script in https://github.com/blindsidenetworks/scalelite-run