### PR TITLE
BBBSL-20: Add server load increment method

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -77,6 +77,14 @@ class Server < ApplicationRedisRecord
     super
   end
 
+  # Apply a concurrency-safe adjustment to the server load
+  def increment_load(amount)
+    with_connection do |redis|
+      self.load = redis.zincrby('server_load', amount, id)
+      clear_attribute_changes([:load])
+    end
+  end
+
   # Find a server by ID
   def self.find(id)
     with_connection do |redis|


### PR DESCRIPTION
This is intended to be used during meeting create, as a way to do an
immediate, atomic update to the server load.