### PR TITLE
BBBSL-8: Made isMeetingRunning return false if meeting doesnt exist

### DIFF
--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -58,9 +58,9 @@ class BigBlueButtonApiController < ApplicationController
     begin
       meeting = Meeting.find(params[:meetingID])
     rescue ApplicationRedisRecord::RecordNotFound
-      # Respond with MeetingNotFoundError if the meeting could not be found
+      # Respond with false if the meeting could not be found
       logger.info("The requested meeting #{params[:meetingID]} does not exist")
-      raise MeetingNotFoundError
+      return render(xml: not_running_response)
     end
 
     server = meeting.server

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -44,4 +44,14 @@ module ApiHelper
       end
     end
   end
+
+  # Not running response if meeting doesn't exist in database
+  def not_running_response
+    Nokogiri::XML::Builder.new do |xml|
+      xml.response do
+        xml.returncode('SUCCESS')
+        xml.running('false')
+      end
+    end
+  end
 end

--- a/test/controllers/bigbluebutton_api_controller_test.rb
+++ b/test/controllers/bigbluebutton_api_controller_test.rb
@@ -89,16 +89,13 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with MeetingNotFoundError if meeting is not found in database for isMeetingRunning' do
+  test 'responds with false if meeting is not found in database for isMeetingRunning' do
     get bigbluebutton_api_is_meeting_running_url, params: { meetingID: 'test' }
 
     response_xml = Nokogiri::XML(@response.body)
 
-    expected_error = MeetingNotFoundError.new
-
-    assert_equal 'FAILED', response_xml.at_xpath('/response/returncode').text
-    assert_equal expected_error.message_key, response_xml.at_xpath('/response/messageKey').text
-    assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
+    assert_equal 'SUCCESS', response_xml.at_xpath('/response/returncode').text
+    assert_equal 'false', response_xml.at_xpath('/response/running').text
   end
 
   # getMeetings


### PR DESCRIPTION
To stay consistent with how BigBlueButton servers work, isMeetingRunning should return false in all situations except when the meeting can be found in the LB database and the meeting is actually running on the BigBlueButton server