### PR TITLE
BBBSL-29: Added 'status' rake task that displays all servers and all meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,29 @@ Note that the server won't be used for new meetings until after the next time th
 Disable a server and clear all meeting state.
 This method is used to recover from a crashed BigBlueButton server.
 After the meeting state is cleared, anyone who tries to join a meeting that was previously on this server will instead be directed to a new meeting on a different server.
+
+## Monitoring
+
+### Check the status of the entire deployment
+```sh
+./bin/rake status
+```
+
+This will print a summary of details for each server aswell as details for every meeting on that server which looks like this:
+
+```
+id: 2d2d674a-c6bb-48f3-8ad4-68f33a80a5b7
+        url: https://test-install.blindsidenetworks.com/bigbluebutton/api
+        secret: 8cd8ef52e8e101574e400365b55e11a6
+        enabled
+        load: 2.0
+        online
+        total users: 3
+        meetings:
+                id: b4b208121b53b5e7d952333945e1fb5d4a2c4fcd
+			name: Room 1
+			users: 1
+		id: 57be4d8cee1befa3de19ef7b439f95df79b50862
+			name: Room 2
+			users: 2
+```

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -4,7 +4,7 @@ desc('List configured BigBlueButton servers')
 task servers: :environment do
   servers = Server.all
   puts('No servers are configured') if servers.empty?
-  Server.all.each do |server|
+  servers.each do |server|
     puts("id: #{server.id}")
     puts("\turl: #{server.url}")
     puts("\tsecret: #{server.secret}")

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+desc('List all BigBlueButton servers and all meetings currently running')
+task status: :environment do
+  include ApiHelper
+
+  servers = Server.all
+  puts('No servers are configured') if servers.empty?
+
+  servers.each do |server|
+    puts("id: #{server.id}")
+    puts("\turl: #{server.url}")
+    puts("\tsecret: #{server.secret}")
+    puts("\t#{server.enabled ? 'enabled' : 'disabled'}")
+    puts("\tload: #{server.load.presence || 'unavailable'}")
+    puts("\t#{server.online ? 'online' : 'offline'}")
+
+    response = get_req(encode_bbb_uri('getMeetings', server.url, server.secret))
+    meetings = response.xpath('/response/meetings/meeting')
+
+    server_users = 0
+    meetings.each do |meeting|
+      count = meeting.at_xpath('participantCount')
+      server_users += count.present? ? count.text.to_i : 0
+    end
+
+    puts("\ttotal users: #{server_users}")
+
+    puts("\tmeetings:") if meetings.present?
+    meetings.each do |meeting|
+      puts("\t\tid: #{meeting.at_xpath('meetingID').text}")
+      puts("\t\t\tname: #{meeting.at_xpath('meetingName').text}")
+      puts("\t\t\tusers: #{meeting.at_xpath('participantCount')&.text}")
+    end
+  end
+end


### PR DESCRIPTION
This rake task currently displays the same server info as the `servers` rake task, along with:
- total users on the server
- every meeting on the server

For every meeting, it displays:
- meeting id
- meeting name
- number of users in that specific meeting
