### PR TITLE
Set the BUILD_NUMBER when building the docker image on gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,12 +57,14 @@ docker:
     - docker build
         --target builder
         --build-arg BUILDKIT_INLINE_CACHE=1
+        --build-arg BUILD_NUMBER="${CI_COMMIT_TAG:-${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}}"
         --cache-from $CI_REGISTRY_IMAGE/builder:$CI_COMMIT_REF_SLUG
         --tag $CI_REGISTRY_IMAGE/builder:$CI_COMMIT_REF_SLUG
         .
     - docker build
         --target api
         --build-arg BUILDKIT_INLINE_CACHE=1
+        --build-arg BUILD_NUMBER="${CI_COMMIT_TAG:-${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}}"
         --cache-from $CI_REGISTRY_IMAGE/builder:$CI_COMMIT_REF_SLUG
         --cache-from $CI_REGISTRY_IMAGE/api:$CI_COMMIT_REF_SLUG
         --cache-from $CI_REGISTRY_IMAGE/poller:$CI_COMMIT_REF_SLUG
@@ -71,6 +73,7 @@ docker:
     - docker build
         --target poller
         --build-arg BUILDKIT_INLINE_CACHE=1
+        --build-arg BUILD_NUMBER="${CI_COMMIT_TAG:-${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}}"
         --cache-from $CI_REGISTRY_IMAGE/builder:$CI_COMMIT_REF_SLUG
         --cache-from $CI_REGISTRY_IMAGE/api:$CI_COMMIT_REF_SLUG
         --cache-from $CI_REGISTRY_IMAGE/poller:$CI_COMMIT_REF_SLUG

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ USER scalelite:scalelite
 ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=1
 COPY --from=builder --chown=scalelite:scalelite /srv/scalelite ./
 
-ARG build_number
-ENV BUILD_NUMBER=$build_number
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER=${BUILD_NUMBER}
 
 FROM application AS poller
 


### PR DESCRIPTION
This will set it to the tag name when building a tag, otherwise it will use `branch-<githash>`