### PR TITLE
BBBSL-43: Fix reference to loop variable in recording metadata import

### DIFF
--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -88,7 +88,7 @@ class Recording < ApplicationRecord
         logger.debug(recording.inspect)
 
         metadata_params.each do |metadatum_params|
-          metadatum = recording.metadata.find_or_initialize_by(key: metadata_params[:key])
+          metadatum = recording.metadata.find_or_initialize_by(key: metadatum_params[:key])
           metadatum.assign_attributes(metadatum_params)
           metadatum.save!
           logger.debug(metadatum.inspect)

--- a/lib/tasks/recordings.rake
+++ b/lib/tasks/recordings.rake
@@ -16,6 +16,7 @@ namespace :recordings do
         RecordingImporter.import(file)
       rescue StandardError => e
         Rails.logger.error("Failed to import recording: #{e}")
+        Rails.logger.warn(e.full_message(highlight: false, order: :top))
       end
     end
     listener.only(/\.tar$/)


### PR DESCRIPTION
Also log the backtrace when an import fails to assist debugging.