### PR TITLE
use video_streams and participants in computing server load

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `RECORDING_WORK_DIR`: Directory where temporary files from recording transfer/import are extracted. Defaults to `/var/bigbluebutton/recording/scalelite`
 * `RECORDING_PUBLISH_DIR`: Directory where published recording files are placed to make them available to the web server. Defaults to `/var/bigbluebutton/published`
 * `RECORDING_UNPUBLISH_DIR`: Directory where unpublished recording files are placed to make them unavailable to the web server. Defaults to `/var/bigbluebutton/unpublished`
+* `LOAD_WEIGHT_VIDEOS`: Integer factor the number of video streams on a server are multiplied with in load calculation. Defaults to 100.
+* `LOAD_WEIGHT_USERS`: Integer factor the number of video streams on a server are multiplied with in load calculation. Defaults to 10.
+* `LOAD_WEIGHT_MEETINGS`: Integer factor the number of video streams on a server are multiplied with in load calculation. Defaults to 1.
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/lib/tasks/poll.rake
+++ b/lib/tasks/poll.rake
@@ -33,7 +33,20 @@ namespace :poll do
       Rails.logger.debug("Polling Server id=#{server.id}")
       resp = get_post_req(encode_bbb_uri('getMeetings', server.url, server.secret))
       meetings = resp.xpath('/response/meetings/meeting')
-      server.load = meetings.length
+
+      server_users = 0
+      video_streams = 0
+
+      meetings.each do |meeting|
+        count = meeting.at_xpath('participantCount')
+        users = count.present? ? count.text.to_i : 0
+        server_users += users
+
+        streams = meeting.at_xpath('videoCount')
+        video_streams += streams.present? ? streams.text.to_i : 0
+      end
+
+      server.load = video_streams * 100 + server_users * 10 + meetings.length
       server.online = true
     rescue StandardError => e
       Rails.logger.warn("Failed to get server id=#{server.id} status: #{e}")

--- a/lib/tasks/poll.rake
+++ b/lib/tasks/poll.rake
@@ -28,6 +28,10 @@ namespace :poll do
   task servers: :environment do
     include ApiHelper
 
+    weight_videos = ENV.has_key?('LOAD_WEIGHT_VIDEOS') ? ENV['LOAD_WEIGHT_VIDEOS'].to_i : 100
+    weight_users = ENV.has_key?('LOAD_WEIGHT_USERS') ? ENV['LOAD_WEIGHT_USERS'].to_i : 10
+    weight_meetings = ENV.has_key?('LOAD_WEIGHT_MEETINGS') ? ENV['LOAD_WEIGHT_MEETINGS'].to_i : 1
+
     Rails.logger.debug('Polling servers')
     Server.all.each do |server|
       Rails.logger.debug("Polling Server id=#{server.id}")
@@ -46,7 +50,7 @@ namespace :poll do
         video_streams += streams.present? ? streams.text.to_i : 0
       end
 
-      server.load = video_streams * 100 + server_users * 10 + meetings.length
+      server.load = video_streams * weight_videos + server_users * weight_users + meetings.length * weight_meetings
       server.online = true
     rescue StandardError => e
       Rails.logger.warn("Failed to get server id=#{server.id} status: #{e}")

--- a/lib/tasks/poll.rake
+++ b/lib/tasks/poll.rake
@@ -28,9 +28,9 @@ namespace :poll do
   task servers: :environment do
     include ApiHelper
 
-    weight_videos = ENV.has_key?('LOAD_WEIGHT_VIDEOS') ? ENV['LOAD_WEIGHT_VIDEOS'].to_i : 100
-    weight_users = ENV.has_key?('LOAD_WEIGHT_USERS') ? ENV['LOAD_WEIGHT_USERS'].to_i : 10
-    weight_meetings = ENV.has_key?('LOAD_WEIGHT_MEETINGS') ? ENV['LOAD_WEIGHT_MEETINGS'].to_i : 1
+    weight_videos = ENV.key?('LOAD_WEIGHT_VIDEOS') ? ENV['LOAD_WEIGHT_VIDEOS'].to_i : 100
+    weight_users = ENV.key?('LOAD_WEIGHT_USERS') ? ENV['LOAD_WEIGHT_USERS'].to_i : 10
+    weight_meetings = ENV.key?('LOAD_WEIGHT_MEETINGS') ? ENV['LOAD_WEIGHT_MEETINGS'].to_i : 1
 
     Rails.logger.debug('Polling servers')
     Server.all.each do |server|


### PR DESCRIPTION
As announced in #99 I had a go at changing the load computation. I borrowed code from the 'status' task and just multiply video_streams by 100, Users by 10 and add everything together with the meeting count. I don't know if there's a better way to compute the load or whether this might lead to an overflow of the variable in some configuration...

Adding a meeting still increases the load by 1 - I don't know whether that's still enough or whether it's needed at all, but it will be overwritten after the next polling cycle anyway.