### PR TITLE
BBBSL-53: NGINX now forces ssl enabled websites to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ To switch your Front-End application to use Scalelite instead of a single BigBlu
 These variables are used by the service startup scripts in the Docker images, but are not used if you are deploying the application in a different way.
 
 * `NGINX_SSL`: Set this variable to enable the "nginx" image to listen on SSL. If you enable this, then you must bind mount the files `/etc/nginx/ssl/live/$URL_HOST/fullchain.pem` and `/etc/nginx/ssl/live/$URL_HOST/privkey.pem` (containing the certificate plus intermediates and the private key respectively) into the Docker image. Alternately, you can mount the entire `/etc/letsencrypt` directory from certbot to `/etc/nginx/ssl` instead.
+* `BEHIND_PROXY`: Set to true if scalelite is behind a proxy or load balancer.
 * `POLL_INTERVAL`: Used by the "poller" image to set the interval at which BigBlueButton servers are polled, in seconds. Defaults to 60.
 * `RECORDING_IMPORT_POLL`: Whether or not to poll the recording spool directory for new recordings. Defaults to "true". If the recording poll directory is on a local filesystem where inotify works, you can set this to "false" to reduce CPU overhead.
 * `RECORDING_IMPORT_POLL_INTERVAL`: How often to check the recording spool directory for new recordings, in seconds (when running in poll mode). Defaults to 60.

--- a/nginx/conf.d/scalelite-proxy.template
+++ b/nginx/conf.d/scalelite-proxy.template
@@ -1,0 +1,27 @@
+access_log stderr combined;
+
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	location / {
+            proxy_pass http://scalelite-api:3000;
+
+            proxy_read_timeout 60s;
+            proxy_redirect off;
+
+            proxy_set_header  Host $http_host;
+
+            proxy_set_header  X-Real-IP $remote_addr;
+            proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_headers_hash_max_size 512;
+            proxy_headers_hash_bucket_size 128;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+            proxy_http_version 1.1;
+    }
+
+    # BigBlueButton recording playback
+    include /etc/bigbluebutton/nginx/*.nginx;
+}

--- a/nginx/conf.d/scalelite-ssl.template
+++ b/nginx/conf.d/scalelite-ssl.template
@@ -4,6 +4,10 @@ server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
+    location / {
+        return  301 https://$host$request_uri;
+      }
+      
 	include conf.d/scalelite.common;
 }
 

--- a/nginx/start
+++ b/nginx/start
@@ -16,7 +16,6 @@ else
 	echo "Using non-SSL configuration template."
 	nginx_template=/etc/nginx/conf.d/scalelite.template
 fi
-
 envsubst '$URL_HOST' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
 unset nginx_template
 

--- a/nginx/start
+++ b/nginx/start
@@ -9,10 +9,14 @@ echo "Generating templated nginx configuration..."
 if [ -n "$NGINX_SSL" ] ; then
 	echo "Using SSL configuration template."
 	nginx_template=/etc/nginx/conf.d/scalelite-ssl.template
+elif [ -n "$BEHIND_PROXY" ] ; then
+  echo "Using proxy configuration template."
+  nginx_template=/etc/nginx/conf.d/scalelite-proxy.template
 else
 	echo "Using non-SSL configuration template."
 	nginx_template=/etc/nginx/conf.d/scalelite.template
 fi
+
 envsubst '$URL_HOST' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
 unset nginx_template
 


### PR DESCRIPTION
Creates a new nginx template and ENV variable for scalelite behind a proxy or load balancer.