### PR TITLE
recording: strip whitespace around links in recording metadata

### DIFF
--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -59,7 +59,8 @@ class Recording < ApplicationRecord
     # Playback format
     playback_format_params = {}
     playback_xml = recording_xml.at_xpath('playback')
-    link = playback_xml.at_xpath('link')&.text
+    link_raw = playback_xml.at_xpath('link')&.text
+    link = link_raw.strip
     playback_format_params[:format] = playback_xml.at_xpath('format')&.text
     duration = playback_xml.at_xpath('duration')&.text
     playback_format_params[:length] = (duration.to_f / 60_000).round if duration.present?
@@ -74,7 +75,7 @@ class Recording < ApplicationRecord
           width: image_xml['width']&.to_i,
           height: image_xml['height']&.to_i,
           alt: image_xml['alt'],
-          url: URI(image_xml.text).path,
+          url: URI(image_xml.text.strip).path,
           sequence: i,
         }
       end


### PR DESCRIPTION
I got this error for the recording import:

```
ERROR -- : Failed to import recording: bad URI(is not URI?): "\n      https://node2.xxx/playback/presentation/2.0/playback.html?meetingId=asdfasdfasdfasdf-123123123\n    "
```

This is the `metadata.xml`:
```
  <playback>
    <format>presentation</format>
    <link>
      https://node2.xxx/playback/presentation/2.0/playback.html?meetingId=asdfasdfasdfasdf-123123123
    </link>
    <processing_time>13684</processing_time>
    <duration>8167</duration>
    <size>639990</size>
```

So probably the simple fix is to strip the newlines.

Thanks for this software! (Also my first dive into Ruby ever).