### PR TITLE
Rationalising the UID and GID of bigbluebutton user in Scalelite containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ COPY nginx /etc/nginx/
 EXPOSE 80
 EXPOSE 443
 ENV NGINX_HOSTNAME=localhost
+ENV GID=997
+ENV UID=997
 CMD [ "/etc/nginx/start", "-g", "daemon off;" ]
 
 FROM alpine AS base
@@ -39,9 +41,9 @@ RUN apk add --no-cache \
     ruby-bundler \
     ruby-json \
     tini \
-    tzdata \
-    && addgroup scalelite \
-    && adduser -h /srv/scalelite -G scalelite -D scalelite
+    tzdata 
+RUN addgroup -S -g 997 scalelite \
+    && adduser -S -G scalelite -u 997 -s /bin/false -h /srv/scalelite scalelite
 WORKDIR /srv/scalelite
 
 FROM base as builder

--- a/README.oeru
+++ b/README.oeru
@@ -1,0 +1,1 @@
+Insight on Blindside Networks' docker process: https://github.com/blindsidenetworks/scalelite/blob/master/.gitlab-ci.yml#L59

--- a/oeru_build.sh
+++ b/oeru_build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Build these containers...
+
+ORG=oeru
+BASE=scalelite
+TARGETS="build api poller recording-importer bbb-playback nginx"
+DB="docker build"
+DP="docker push"
+echo "create containers"
+
+for TARGET in $TARGETS 
+do
+    echo
+    echo "************ start $TARGET *************"
+    echo "Building docker container $ORG/$BASE-$TARGET"
+    $DB --target $TARGET --tag $ORG/$BASE-$TARGET .
+    echo "Pushing $ORG/$BASE-$TARGET to Docker Hub"
+    $DP $ORG/$BASE-$TARGET
+    echo "************ $TARGET done *************"
+done


### PR DESCRIPTION
This pull request covers my tweaks to the Scalelite Dockerfile to set the UID and GID both to 997 as seems to be the default set via the bbb-install script for BBB instances. I have also included a quick script for building an deploying our containers that someone else can easily repurpose. 

** Reasoning **

I have found it difficult (and likely dangerous) to manage recordings on instances of BBB, created using the bbb-install script on Ubuntu 16.04 hosts, sitting behind a combined Scalelite and Greenlight load balancer (running in Docker via Docker-Compose). 

I have succeeded in setting up NFS and having Scalelite see the same recordings file system as my two BBB "workers". But I haven't got the processing of recordings working properly using the existing Scalelite documentation plus insights from #83, #129, #147, and other issues. I noticed that some people had got the recordings working properly.  I've managed to create a *few* published recordings by manually pushing raw recordings through the process via bbb-record and changes of ownership for the files and directories involved, but I have not yet had any recordings "published" without resorting to `sudo -n -u bigbluebutton bash /var/bigbluebutton/scalelite_batch_import.sh`. 

It appears some folks have managed to get it working (I'm not sure how, to be honest - I suspect some undocumented umask fiddling or xattr or similar)... by making the whole /var/bigbluebutton/* world read & writeable... but even that is, I suspect, temporary. 

The main source of problems seems to be the difference in UID, GID of bigbluebutton in the Docker containers (1000, 1000) and on the BBB workers (997, 997). The recommendation in #147 involves using a separate group (this is where, I think, some tricky user mapping or umasks would be necessary) but that seems unnecessarily complicated.

My approach is to set the UID and GIDs for the bigbluebutton user in the Scalelite Docker containers.

** Caveats **

This implementation might be slightly better if it used ENV variables or some other mechanism to abstract the actual UID and GIDs in the event that people are using some other system for implementing the BBB works that doesn't result in the specific UID and GID I've used. But in that case, they'll be no worse off than they are with the default Scalelite Docker containers' choice of 1000, 1000.
 