### PR TITLE
Sort Status Table

### DIFF
--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -45,7 +45,7 @@ task status: :environment do
                       ))
 
     # Sort list of servers
-    servers_info = servers_info.sort { |a, b| a[:hostname] <=> b[:hostname] }
+    servers_info = servers_info.sort_by(&:hostname)
   end
 
   table = Tabulo::Table.new(servers_info, border: :blank) do |t|

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -43,6 +43,9 @@ task status: :environment do
                         largest: users_in_largest_meeting,
                         videos: video_streams
                       ))
+
+    # Sort list of servers
+    servers_info = servers_info.sort { |a, b| a[:hostname] <=> b[:hostname] }
   end
 
   table = Tabulo::Table.new(servers_info, border: :blank) do |t|


### PR DESCRIPTION
This patch sorts the status table by hostname making it much more
readable, especially if you have a large number of hosts.

Before:

```
% ./bin/rake status
 HOSTNAME    STATE    STATUS  MEETINGS  USERS  LARGEST MEETING  VIDEOS
 a.xy      disabled  offline         0      0                0       0
 y.xy      disabled  offline         0      0                0       0
 c.xy      disabled  offline         0      0                0       0
 r.xy      disabled  offline         0      0                0       0
 z.xy      disabled  offline         0      0                0       0
```

After:
```
% ./bin/rake status
 HOSTNAME    STATE    STATUS  MEETINGS  USERS  LARGEST MEETING  VIDEOS
 a.xy      disabled  offline         0      0                0       0
 c.xy      disabled  offline         0      0                0       0
 r.xy      disabled  offline         0      0                0       0
 y.xy      disabled  offline         0      0                0       0
 z.xy      disabled  offline         0      0                0       0
```