### PR TITLE
Ensure Spool Directory Exists

### DIFF
--- a/bigbluebutton/scalelite_post_publish.rb
+++ b/bigbluebutton/scalelite_post_publish.rb
@@ -59,6 +59,7 @@ begin
       || raise('Failed to create recording archive')
   end
 
+  FileUtils.mkdir_p(spool_dir)
   puts("Transferring recording archive to #{spool_dir}")
   system('rsync', '--verbose', '--protect-args', *extra_rsync_opts, archive_file, spool_dir) \
     || raise('Failed to transfer recording archive')


### PR DESCRIPTION
This patch tries to create the spool directory if it does not exist.
Otherwise rsync will copy the archive to the name of the directory (not
into the directory) and will succeed in a somewhat broken state.