### PR TITLE
tweak for clustering scalelite behind proxy

### DIFF
--- a/nginx/conf.d/scalelite-proxy.template
+++ b/nginx/conf.d/scalelite-proxy.template
@@ -5,7 +5,7 @@ server {
   listen [::]:80 default_server;
 
   location / {
-    proxy_pass http://scalelite-api:3000;
+    proxy_pass http://$SCALELITE_API:3000;
 
     proxy_read_timeout 60s;
     proxy_redirect off;

--- a/nginx/start
+++ b/nginx/start
@@ -16,14 +16,15 @@ else
 	echo "Using non-SSL configuration template."
 	nginx_template=/etc/nginx/conf.d/scalelite.template
 fi
-envsubst '$URL_HOST' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
+SCALELITE_API=${SCALELITE_API-scalelite-api}
+envsubst '$URL_HOST:$SCALELITE_API' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
 unset nginx_template
 
 mkdir -p /run/nginx
 
 echo "Starting nginx periodic reload process..."
 while :; do
-	sleep 6h 
+	sleep 6h
 	echo "Reloading nginx..."
 	nginx -s reload
 done &


### PR DESCRIPTION
The docker container name is variable but the value by default is still scalelite-api