### PR TITLE
SL-67 & SL-68 : Add separate routes for each recording api

### DIFF
--- a/app/constraints/recording_constraint.rb
+++ b/app/constraints/recording_constraint.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class RecordingConstraint
-  def self.matches?(request)
-    /Recordings/ =~ request.path
-  end
-end

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -366,7 +366,8 @@ class BigBlueButtonApiController < ApplicationController
 
   def get_recordings_disabled
     logger.debug('The recording feature have been disabled')
-    render(xml: no_recordings_response)
+    @recordings = []
+    render(:get_recordings)
   end
 
   def recordings_disabled
@@ -399,17 +400,6 @@ class BigBlueButtonApiController < ApplicationController
       xml.response do
         xml.returncode('SUCCESS')
         xml.running('false')
-      end
-    end
-  end
-
-  # No recordings response if their are no saved recordings or recording feature is disabled
-  def no_recordings_response
-    Nokogiri::XML::Builder.new do |xml|
-      xml.response do
-        xml.returncode('SUCCESS')
-        xml.messageKey('noRecordings')
-        xml.message('There are no recordings for the meeting(s).')
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
     get 'join', to: 'bigbluebutton_api#join'
     if 'true'.casecmp?(ENV['RECORDING_DISABLED'])
       get('getRecordings', to: 'bigbluebutton_api#get_recordings_disabled', as: :get_recordings)
-      get('*Recordings', to: 'bigbluebutton_api#recordings_disabled', constraints: RecordingConstraint, via: :all)
+      get('publishRecordings', to: 'bigbluebutton_api#recordings_disabled', as: :publish_recordings)
+      get('updateRecordings', to: 'bigbluebutton_api#recordings_disabled', as: :update_recordings)
+      get('deleteRecordings', to: 'bigbluebutton_api#recordings_disabled', as: :delete_recordings)
     else
       get('getRecordings', to: 'bigbluebutton_api#get_recordings', as: :get_recordings)
       get('publishRecordings', to: 'bigbluebutton_api#publish_recordings', as: :publish_recordings)

--- a/test/controllers/bigbluebutton_api_controller_test.rb
+++ b/test/controllers/bigbluebutton_api_controller_test.rb
@@ -932,7 +932,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select 'response>returncode', 'SUCCESS'
     assert_select 'response>messageKey', 'noRecordings'
-    assert_select 'response>message', 'There are no recordings for the meeting(s).'
+    assert_select 'response>message', 'There are not recordings for the meetings'
   end
 
   test 'publishRecordings returns notFound if RECORDING_DISABLED flag is set to true' do
@@ -952,17 +952,6 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     mock_env('RECORDING_DISABLED' => 'true') do
       reload_routes!
       get 'http://www.example.com/bigbluebutton/api/updateRecordings', params: params
-    end
-    assert_response :success
-    assert_select 'response>returncode', 'FAILED'
-    assert_select 'response>messageKey', 'notFound'
-    assert_select 'response>message', 'We could not find recordings'
-  end
-
-  test 'Any Recordings API returns notFound if RECORDING_DISABLED flag is set to true' do
-    mock_env('RECORDING_DISABLED' => 'true') do
-      reload_routes!
-      get 'http://www.example.com/bigbluebutton/api/testRecordings'
     end
     assert_response :success
     assert_select 'response>returncode', 'FAILED'


### PR DESCRIPTION
* Separate routes for each recording api should be configured when recordings are disabled.
* getRecordings and getMeetings response with disabled  condition has incorrect format.