### PR TITLE
SL-83: Make timeouts on requests to BBB api configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `RECORDING_DISABLED`: Disable the recording feature and all its associated api's, by setting this value as `true`.
 * `GET_MEETINGS_API_DISABLED`: Disable GET_MEETINGS API by setting this value as `true`.
 * `POLLER_THREADS`: The number of threads to run in the poller process. The default is 5.
+* `CONNECT_TIMEOUT`: The timeout for establishing a network connection to the BigBlueButton server in the load balancer and poller in seconds. Default is 5 seconds. Floating point numbers can be used for timeouts less than 1 second.
+* `RESPONSE_TIMEOUT`: The timeout to wait for a response after sending a request to the BigBlueButton server in the load balancer and poller in seconds. Default is 10 seconds. Floating point numbers can be used for timeouts less than 1 second.
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -217,7 +217,7 @@ class BigBlueButtonApiController < ApplicationController
       end
       # Reraise the error
       raise e
-    rescue RecordNotDestroyed => e
+    rescue ApplicationRedisRecord::RecordNotDestroyed => e
       logger.warn("Error #{e} deleting meeting #{params[:meetingID]} from server #{server.id}")
     rescue StandardError => e
       logger.warn("Error #{e} accessing meeting #{params[:meetingID]} on server #{server.id}.")

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -40,7 +40,7 @@ class BigBlueButtonApiController < ApplicationController
 
     begin
       # Send a GET request to the server
-      response = get_post_req(uri)
+      response = get_post_req(uri, **bbb_req_timeout(server))
     rescue BBBError
       # Reraise the error
       raise
@@ -74,7 +74,7 @@ class BigBlueButtonApiController < ApplicationController
 
     begin
       # Send a GET request to the server
-      response = get_post_req(uri)
+      response = get_post_req(uri, **bbb_req_timeout(server))
     rescue BBBError
       # Reraise the error
       raise
@@ -173,7 +173,7 @@ class BigBlueButtonApiController < ApplicationController
       body = request.post? ? request.body.read : ''
 
       # Send a GET/POST request to the server
-      response = get_post_req(uri, body)
+      response = get_post_req(uri, body, **bbb_req_timeout(server))
     rescue BBBError
       # Reraise the error to return error xml to caller
       raise
@@ -208,7 +208,7 @@ class BigBlueButtonApiController < ApplicationController
       meeting.destroy!
 
       # Send a GET request to the server
-      response = get_post_req(uri)
+      response = get_post_req(uri, **bbb_req_timeout(server))
     rescue BBBError => e
       if e.message_key == 'notFound'
         # If the meeting is not found, delete the meeting from the load balancer database

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -6,7 +6,6 @@ module ApiHelper
   extend ActiveSupport::Concern
   include BBBErrors
 
-  REQUEST_TIMEOUT = 10
   CHECKSUM_LENGTH = 40
 
   # Verify checksum
@@ -39,7 +38,7 @@ module ApiHelper
   end
 
   # GET/POST request
-  def get_post_req(uri, body = '')
+  def get_post_req(uri, body = '', **options)
     # If body is passed and has a value, setup POST request
     if body.present?
       req = Net::HTTP::Post.new(uri.request_uri)
@@ -49,8 +48,13 @@ module ApiHelper
       req = Net::HTTP::Get.new(uri.request_uri)
     end
 
-    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
-                                        open_timeout: REQUEST_TIMEOUT, read_timeout: REQUEST_TIMEOUT) do |http|
+    Net::HTTP.start(
+      uri.host,
+      uri.port,
+      use_ssl: uri.scheme == 'https',
+      open_timeout: options.fetch(:open_timeout) { Rails.configuration.x.open_timeout },
+      read_timeout: options.fetch(:read_timeout) { Rails.configuration.x.read_timeout }
+    ) do |http|
       res = http.request(req)
       doc = Nokogiri::XML(res.body)
       returncode = doc.at_xpath('/response/returncode')

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -37,6 +37,20 @@ module ApiHelper
     uri
   end
 
+  # Calculate a timeout based on server state to pass to get_post_req options
+  def bbb_req_timeout(server)
+    unless server.online
+      # Use values that are 1/10 the normal values, but clamp to a minimum.
+      # If the original configured timeout value is below the minimum, then use that instead.
+      return {
+        open_timeout: [[0.2, Rails.configuration.x.open_timeout].min, Rails.configuration.x.open_timeout / 10].max,
+        read_timeout: [[0.5, Rails.configuration.x.read_timeout].min, Rails.configuration.x.read_timeout / 10].max,
+      }
+    end
+
+    {}
+  end
+
   # GET/POST request
   def get_post_req(uri, body = '', **options)
     # If body is passed and has a value, setup POST request

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,14 @@ module Scalelite
     # and set it to offline
     config.x.server_unhealthy_threshold = ENV.fetch('SERVER_UNHEALTHY_THRESHOLD', '2').to_i
 
+    # Request connection timeout. This is the timeout for the initial TCP/TLS connection, not including
+    # waiting for a response.
+    config.x.open_timeout = ENV.fetch('CONNECT_TIMEOUT', '5').to_f
+
+    # Request response timeout. This is the timeout for waiting for a response after the connection has
+    # been established and the request has been sent.
+    config.x.read_timeout = ENV.fetch('RESPONSE_TIMEOUT', '10').to_f
+
     # Directory to monitor for recordings transferred from BigBlueButton servers
     config.x.recording_spool_dir = File.absolute_path(
       ENV.fetch('RECORDING_SPOOL_DIR') { '/var/bigbluebutton/spool' }

--- a/test/controllers/bigbluebutton_api_controller_test.rb
+++ b/test/controllers/bigbluebutton_api_controller_test.rb
@@ -6,7 +6,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
 
   # /
 
-  test 'responds with only success and version' do
+  test 'index responds with only success and version' do
     Rails.configuration.x.build_number = nil
 
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
@@ -22,7 +22,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'includes build in response if env variable is set' do
+  test 'index includes build in response if env variable is set' do
     Rails.configuration.x.build_number = 'alpha-1'
 
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
@@ -40,7 +40,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
 
   # getMeetingInfo
 
-  test 'responds with the correct meeting info' do
+  test 'getMeetingInfo responds with the correct meeting info' do
     server = Server.create!(url: 'https://test-1.example.com/bigbluebutton/api/', secret: 'test-1')
     Meeting.create!(id: 'test-meeting-1', server: server)
 
@@ -59,7 +59,27 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'test-meeting-1', response_xml.at_xpath('/response/meetingID').content
   end
 
-  test 'responds with MissingMeetingIDError if meeting ID is not passed' do
+  test 'getMeetingInfo responds with appropriate error on timeout' do
+    server = Server.create!(url: 'https://test-1.example.com/bigbluebutton/api/', secret: 'test-1')
+    Meeting.create!(id: 'test-meeting-1', server: server)
+
+    url = 'https://test-1.example.com/bigbluebutton/api/getMeetingInfo?meetingID=test-meeting-1&checksum=a4eee985e3f1f9524a6e2a32d1e35d3703e4cef9'
+
+    stub_request(:get, url)
+      .to_timeout
+
+    BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
+      get bigbluebutton_api_get_meeting_info_url, params: { meetingID: 'test-meeting-1' }
+    end
+
+    response_xml = Nokogiri::XML(@response.body)
+
+    assert_equal 'FAILED', response_xml.at_xpath('/response/returncode').content
+    assert_equal 'internalError', response_xml.at_xpath('/response/messageKey').content
+    assert_equal 'Unable to access meeting on server.', response_xml.at_xpath('/response/message').content
+  end
+
+  test 'getMeetingInfo responds with MissingMeetingIDError if meeting ID is not passed' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_get_meeting_info_url
     end
@@ -73,7 +93,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with MeetingNotFoundError if meeting is not found in database' do
+  test 'getMeetingInfo responds with MeetingNotFoundError if meeting is not found in database' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_get_meeting_info_url, params: { meetingID: 'test' }
     end
@@ -89,7 +109,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
 
   # isMeetingRunning
 
-  test 'responds with the correct meeting status' do
+  test 'isMeetingRunning responds with the correct meeting status' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret', load: 0)
     meeting1 = Meeting.find_or_create_with_server('Demo Meeting', server1)
 
@@ -106,7 +126,25 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert response_xml.at_xpath('/response/running').content
   end
 
-  test 'responds with MissingMeetingIDError if meeting ID is not passed to isMeetingRunning' do
+  test 'isMeetingRunning responds with appropriate error on timeout' do
+    server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret', load: 0)
+    meeting1 = Meeting.find_or_create_with_server('Demo Meeting', server1)
+
+    stub_request(:get, encode_bbb_uri('isMeetingRunning', server1.url, server1.secret, 'meetingID' => meeting1.id))
+      .to_timeout
+
+    BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
+      get bigbluebutton_api_is_meeting_running_url, params: { meetingID: meeting1.id }
+    end
+
+    response_xml = Nokogiri::XML(@response.body)
+
+    assert_equal 'FAILED', response_xml.at_xpath('/response/returncode').content
+    assert_equal 'internalError', response_xml.at_xpath('/response/messageKey').content
+    assert_equal 'Unable to access meeting on server.', response_xml.at_xpath('/response/message').content
+  end
+
+  test 'isMeetingRunning responds with MissingMeetingIDError if meeting ID is not passed to isMeetingRunning' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_is_meeting_running_url
     end
@@ -120,7 +158,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with false if meeting is not found in database for isMeetingRunning' do
+  test 'isMeetingRunning responds with false if meeting is not found in database for isMeetingRunning' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_is_meeting_running_url, params: { meetingID: 'test' }
     end
@@ -133,7 +171,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
 
   # getMeetings
 
-  test 'responds with the correct meetings' do
+  test 'getMeetings responds with the correct meetings' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret', load: 1, online: true)
     server2 = Server.create(url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret', load: 1, online: true)
 
@@ -155,7 +193,32 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert response_xml.xpath('//meeting[text()="test-meeting-2"]').present?
   end
 
-  test 'responds with noMeetings if there are no meetings on any server' do
+  test 'getMeetings responds with appropriate error on timeout' do
+    server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret', load: 1, online: true)
+    server2 = Server.create(url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret', load: 1, online: true)
+    server3 = Server.create(url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret', load: 1, online: true)
+
+    stub_request(:get, encode_bbb_uri('getMeetings', server1.url, server1.secret))
+      .to_return(body: '<response><returncode>SUCCESS</returncode><meetings>' \
+                       '<meeting>test-meeting-1<meeting></meetings></response>')
+    stub_request(:get, encode_bbb_uri('getMeetings', server2.url, server2.secret))
+      .to_timeout
+    stub_request(:get, encode_bbb_uri('getMeetings', server3.url, server3.secret))
+      .to_return(body: '<response><returncode>SUCCESS</returncode><meetings>' \
+                       '<meeting>test-meeting-3<meeting></meetings></response>')
+
+    BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
+      get bigbluebutton_api_get_meetings_url
+    end
+
+    response_xml = Nokogiri::XML(@response.body)
+
+    assert_equal 'FAILED', response_xml.at_xpath('/response/returncode').content
+    assert_equal 'internalError', response_xml.at_xpath('/response/messageKey').content
+    assert_equal 'Unable to access server.', response_xml.at_xpath('/response/message').content
+  end
+
+  test 'getMeetings responds with noMeetings if there are no meetings on any server' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_get_meetings_url
     end
@@ -167,7 +230,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'No meetings were found on this server.', response_xml.at_xpath('/response/message').text
   end
 
-  test 'only makes a request to online servers' do
+  test 'getMeetings only makes a request to online servers' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret', load: 1, online: true)
     server2 = Server.create(url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret', load: 1, online: true)
     server3 = Server.create(url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-2-secret', load: 1,
@@ -197,7 +260,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
 
   # /create
 
-  test 'responds with MissingMeetingIDError if meeting ID is not passed to create' do
+  test 'create responds with MissingMeetingIDError if meeting ID is not passed to create' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_create_url
     end
@@ -211,7 +274,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with InternalError if no servers are available in create' do
+  test 'create responds with InternalError if no servers are available in create' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_create_url, params: { meetingID: 'test-meeting-1' }
     end
@@ -225,7 +288,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'creates the room successfully' do
+  test 'create creates the room successfully' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
 
@@ -253,7 +316,29 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, server1.load
   end
 
-  test 'increments the server load by the value of load_multiplier' do
+  test 'create returns an appropriate error on timeout' do
+    server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
+                            secret: 'test-1-secret', enabled: true, load: 0)
+
+    params = {
+      meetingID: 'test-meeting-1',
+    }
+
+    stub_request(:get, encode_bbb_uri('create', server1.url, server1.secret, params))
+      .to_timeout
+
+    BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
+      get bigbluebutton_api_create_url, params: params
+    end
+
+    response_xml = Nokogiri::XML(@response.body)
+
+    assert_equal 'FAILED', response_xml.at_xpath('/response/returncode').content
+    assert_equal 'internalError', response_xml.at_xpath('/response/messageKey').content
+    assert_equal 'Unable to create meeting on server.', response_xml.at_xpath('/response/message').content
+  end
+
+  test 'create increments the server load by the value of load_multiplier' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0, load_multiplier: 7.0)
 
@@ -274,7 +359,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 7, server1.load
   end
 
-  test 'creates the room successfully using POST' do
+  test 'create creates the room successfully using POST' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
 
@@ -302,7 +387,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, server1.load
   end
 
-  test 'sets the duration param to MAX_MEETING_DURATION if set' do
+  test 'create sets the duration param to MAX_MEETING_DURATION if set' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
 
@@ -330,7 +415,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'sets the duration param to MAX_MEETING_DURATION if passed duration is greater than MAX_MEETING_DURATION' do
+  test 'create sets the duration param to MAX_MEETING_DURATION if passed duration is greater than MAX_MEETING_DURATION' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
 
@@ -359,7 +444,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'sets the duration param to MAX_MEETING_DURATION if passed duration is 0' do
+  test 'create sets the duration param to MAX_MEETING_DURATION if passed duration is 0' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
 
@@ -388,7 +473,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'does not set the duration param to MAX_MEETING_DURATION if passed duration is less than MAX_MEETING_DURATION' do
+  test 'create does not set the duration param to MAX_MEETING_DURATION if passed duration is less than MAX_MEETING_DURATION' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
 
@@ -419,7 +504,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
 
   # end
 
-  test 'responds with MissingMeetingIDError if meeting ID is not passed to end' do
+  test 'end responds with MissingMeetingIDError if meeting ID is not passed to end' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_end_url
     end
@@ -432,7 +517,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with MeetingNotFoundError if meeting is not found in database for end' do
+  test 'end responds with MeetingNotFoundError if meeting is not found in database for end' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_end_url, params: { meetingID: 'test-meeting-1' }
     end
@@ -445,7 +530,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with MeetingNotFoundError if meetingID && password are passed but meeting doesnt exist' do
+  test 'end responds with MeetingNotFoundError if meetingID && password are passed but meeting doesnt exist' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
 
@@ -471,7 +556,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with sentEndMeetingRequest if meeting exists and password is correct' do
+  test 'end responds with sentEndMeetingRequest if meeting exists and password is correct' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
     Meeting.find_or_create_with_server('test-meeting-1', server1)
@@ -493,11 +578,42 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 'SUCCESS', response_xml.at_xpath('/response/returncode').text
     assert_equal 'sentEndMeetingRequest', response_xml.at_xpath('/response/messageKey').text
+
+    assert_raises(ApplicationRedisRecord::RecordNotFound) do
+      Meeting.find('test-meeting-1')
+    end
+  end
+
+  test 'end returns error on timeout but still deletes meeting' do
+    server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
+                            secret: 'test-1-secret', enabled: true, load: 0)
+    Meeting.find_or_create_with_server('test-meeting-1', server1)
+
+    params = {
+      meetingID: 'test-meeting-1',
+      password: 'test-password',
+    }
+
+    stub_request(:get, encode_bbb_uri('end', server1.url, server1.secret, params))
+      .to_timeout
+
+    BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
+      get bigbluebutton_api_end_url, params: params
+    end
+    response_xml = Nokogiri::XML(@response.body)
+
+    assert_equal 'FAILED', response_xml.at_xpath('/response/returncode').text
+    assert_equal 'internalError', response_xml.at_xpath('/response/messageKey').text
+    assert_equal 'Unable to access meeting on server.', response_xml.at_xpath('/response/message').text
+
+    assert_raises(ApplicationRedisRecord::RecordNotFound) do
+      Meeting.find('test-meeting-1')
+    end
   end
 
   # join
 
-  test 'responds with MissingMeetingIDError if meeting ID is not passed to join' do
+  test 'join responds with MissingMeetingIDError if meeting ID is not passed to join' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_join_url
     end
@@ -510,7 +626,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'responds with MeetingNotFoundError if meeting is not found in database for join' do
+  test 'join responds with MeetingNotFoundError if meeting is not found in database for join' do
     BigBlueButtonApiController.stub_any_instance(:verify_checksum, nil) do
       get bigbluebutton_api_join_url, params: { meetingID: 'test-meeting-1' }
     end
@@ -523,7 +639,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_error.message, response_xml.at_xpath('/response/message').text
   end
 
-  test 'redirects user to the corrent join url' do
+  test 'join redirects user to the corrent join url' do
     server1 = Server.create(url: 'https://test-1.example.com/bigbluebutton/api/',
                             secret: 'test-1-secret', enabled: true, load: 0)
     meeting = Meeting.find_or_create_with_server('test-meeting-1', server1)


### PR DESCRIPTION
This fixes #439.

Simply making the timeouts shorter and allowing them to be configured to match the environment of a particular deployment should reduce the impact of attempting to make calls on unreachable/slow BigBlueButton servers.

In addition, the timeouts on servers that the poller has marked as offline are shortened, to avoid a pile-up of hanging threads on servers that we suspect aren't going to be able to respond.