### PR TITLE
SL77:Disable recording importer

### DIFF
--- a/lib/recording_importer.rb
+++ b/lib/recording_importer.rb
@@ -9,6 +9,8 @@ class RecordingImporter
   end
 
   def self.import(filename)
+    return if ENV['RECORDING_DISABLED'].casecmp?('true')
+
     logger.info("Importing recording from file: #{filename}")
 
     recording = nil


### PR DESCRIPTION
Handle recording importer, on automated deployments relying on ENV variables (especifically on kubernetes), as disabling recording  can cause a problem because the pod (or container) would be constantly crashing if the database is not set.


