### PR TITLE
SL:70 Change logic for calculating server load

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `POLLER_THREADS`: The number of threads to run in the poller process. The default is 5.
 * `CONNECT_TIMEOUT`: The timeout for establishing a network connection to the BigBlueButton server in the load balancer and poller in seconds. Default is 5 seconds. Floating point numbers can be used for timeouts less than 1 second.
 * `RESPONSE_TIMEOUT`: The timeout to wait for a response after sending a request to the BigBlueButton server in the load balancer and poller in seconds. Default is 10 seconds. Floating point numbers can be used for timeouts less than 1 second.
+* `LOAD_MIN_USER_COUNT`: Minimum user count of a meeting, used for calculating server load. Defaults to 15.
+* `LOAD_JOIN_BUFFER_TIME`: The time(in minutes) until the `LOAD_MIN_USER_COUNT` will be used for calculating server load. Defaults to 15.
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,5 +85,11 @@ module Scalelite
     config.x.recording_unpublish_dir = File.absolute_path(
       ENV.fetch('RECORDING_UNPUBLISH_DIR') { '/var/bigbluebutton/unpublished' }
     )
+
+    # Minimum user count of a meeting, used for calculating server load. Defaults to 15.
+    config.x.load_min_user_count = ENV.fetch('LOAD_MIN_USER_COUNT', 15).to_i
+
+    # The time(in minutes) until the `load_min_user_count` will be used for calculating server load
+    config.x.load_join_buffer_time = ENV.fetch('LOAD_JOIN_BUFFER_TIME', 15).to_i.minutes
   end
 end

--- a/lib/tasks/poll.rake
+++ b/lib/tasks/poll.rake
@@ -38,19 +38,32 @@ namespace :poll do
         resp = get_post_req(encode_bbb_uri('getMeetings', server.url, server.secret))
         meetings = resp.xpath('/response/meetings/meeting')
 
+        total_attendees = 0
+        load_min_user_count = Rails.configuration.x.load_min_user_count
+        x_minutes_ago = Rails.configuration.x.load_join_buffer_time.ago
+
+        meetings.each do |meeting|
+          created_time = Time.zone.at(meeting.xpath('.//createTime').text.to_i / 1000)
+          actual_attendees = meeting.xpath('.//participantCount').text.to_i + meeting.xpath('.//moderatorCount').text.to_i
+          total_attendees += if created_time > x_minutes_ago
+                               [actual_attendees, load_min_user_count].max
+                             else
+                               actual_attendees
+                             end
+        end
         # Reset unhealthy counter so that only consecutive unhealthy calls are counted
         server.reset_unhealthy_counter
 
         if server.online
           # Update the load if the server is currently online
-          server.load = meetings.length * (server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d)
+          server.load = total_attendees
         else
           # Only bring the server online if the number of successful requests is >= the acceptable threshold
           next if server.increment_healthy < Rails.configuration.x.server_healthy_threshold
 
           Rails.logger.info("Server id=#{server.id} is healthy. Bringing back online...")
           server.reset_counters
-          server.load = meetings.length * (server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d)
+          server.load = total_attendees
           server.online = true
         end
       rescue StandardError => e


### PR DESCRIPTION
Change the algorithm for calculating the load on every server: 
New Logic: Server load calculation is now based on number of users, and the SL gives every meeting an assignment of 15 users when it starts, and then post that uses max(actual number of users, 15).
