### PR TITLE
Compute load based on video streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `POLLER_THREADS`: The number of threads to run in the poller process. The default is 5.
 * `CONNECT_TIMEOUT`: The timeout for establishing a network connection to the BigBlueButton server in the load balancer and poller in seconds. Default is 5 seconds. Floating point numbers can be used for timeouts less than 1 second.
 * `RESPONSE_TIMEOUT`: The timeout to wait for a response after sending a request to the BigBlueButton server in the load balancer and poller in seconds. Default is 10 seconds. Floating point numbers can be used for timeouts less than 1 second.
+* `MEETINGS_MIN_USER_COUNT`: Minimum user count of a meeting, used for calculating server load.
+* `MEETING_JOIN_BUFFER_TIME`: The time until the `MEETINGS_MIN_USER_COUNT` will be used for calculating server load.
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `POLLER_THREADS`: The number of threads to run in the poller process. The default is 5.
 * `CONNECT_TIMEOUT`: The timeout for establishing a network connection to the BigBlueButton server in the load balancer and poller in seconds. Default is 5 seconds. Floating point numbers can be used for timeouts less than 1 second.
 * `RESPONSE_TIMEOUT`: The timeout to wait for a response after sending a request to the BigBlueButton server in the load balancer and poller in seconds. Default is 10 seconds. Floating point numbers can be used for timeouts less than 1 second.
-* `MEETINGS_MIN_USER_COUNT`: Minimum user count of a meeting, used for calculating server load.
-* `MEETING_JOIN_BUFFER_TIME`: The time until the `MEETINGS_MIN_USER_COUNT` will be used for calculating server load.
+* `LOAD_MIN_USER_COUNT`: Minimum user count of a meeting, used for calculating server load. The default is 15.
+* `LOAD_JOIN_BUFFER_TIME`: The time until the `LOAD_MIN_USER_COUNT` will be used for calculating server load. The default is 15.
+* `LOAD_MIN_WEBCAM_COUNT` : The minimum number of active webcams, used for calculating server load. The default is 1.
+* `LOAD_SCREENSHARE_COUNT` : Disable counting 1 screenshare for calculating server load by setting this value as `false`
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/lib/tasks/poll.rake
+++ b/lib/tasks/poll.rake
@@ -39,19 +39,19 @@ namespace :poll do
         meetings = resp.xpath('/response/meetings/meeting')
 
         total_load = 0
-        meetings_min_user_count = ENV.fetch('MEETINGS_MIN_USER_COUNT', '15').to_i
-        meetings_min_webcam_count = ENV.fetch('MEETINGS_MIN_WEBCAM_COUNT', '1').to_i
-        meetings_screenshare_count = (ENV.fetch('MEETINGS_SCREENSHARE_COUNT', 'true') == 'true') ? 1 : 0
-        x_minutes_ago = (ENV.fetch('MEETING_JOIN_BUFFER_TIME', '15').to_i).minutes.ago
+        load_min_user_count = ENV.fetch('LOAD_MIN_USER_COUNT', '15').to_i
+        load_min_webcam_count = ENV.fetch('LOAD_MIN_WEBCAM_COUNT', '1').to_i
+        load_screenshare_count = (ENV.fetch('LOAD_SCREENSHARE_COUNT', 'true') == 'true') ? 1 : 0
+        x_minutes_ago = (ENV.fetch('LOAD_JOIN_BUFFER_TIME', '15').to_i).minutes.ago
 
         meetings.each do |meeting|
           created_time = Time.zone.at(meeting.xpath('.//createTime').text.to_i / 1000)
           actual_attendees = meeting.xpath('.//participantCount').text.to_i + meeting.xpath('.//moderatorCount').text.to_i
           actual_webcams = meeting.xpath('.//videoCount').text.to_i                         
           total_load += if created_time > x_minutes_ago
-                          [actual_attendees, meetings_min_user_count].max * (1 + 10 * actual_webcams + 20 * meetings_screenshare_count)
+                          [actual_attendees, load_min_user_count].max * (1 + 10 * actual_webcams + 20 * load_screenshare_count)
                         else
-                           actual_attendees * (1 + 10 * meetings_min_webcam_count + 20 * meetings_screenshare_count)
+                           actual_attendees * (1 + 10 * load_min_webcam_count + 20 * load_screenshare_count)
                         end
         end
         


### PR DESCRIPTION
Hi,

I propose this pull request based on this one https://github.com/blindsidenetworks/scalelite/pull/445
I add the enhancement that load is actually computed based on actual audio and video streams.
We sum up 3 values :
* Normal audio users count for 1
* Webcam users count for 10 (a webcam stream is roughly equivalent to 10 audio streams)
* A screenshare counts for 20 (a sharescreen stream is roughly equivalent to 2 webcam streams)
These values are multiplied by the actual number of participants to get the actual number of streams treated by the server (SFU principle).