### PR TITLE
renamed to documented POLL_INTERVAL and default

### DIFF
--- a/lib/tasks/poll.rake
+++ b/lib/tasks/poll.rake
@@ -4,7 +4,7 @@ require 'concurrent-ruby'
 
 desc 'Run a polling process to continually monitor servers and meetings'
 task :poll, [:interval] => :environment do |_t, args|
-  args.with_defaults(interval: ENV['POLLING_INTERVAL'])
+  args.with_defaults(interval: ENV['POLL_INTERVAL'] || 30) 
   interval = args.interval.to_f
   Rails.logger.info("Running poller with interval #{interval}")
 


### PR DESCRIPTION
Documentation talks about `POLL_INTERVAL` and there is no default value given.
Don't know if the syntax is correct. I'm not a ruby guy.