### PR TITLE
Revert poll rake task default interval change.

### DIFF
--- a/lib/tasks/poll.rake
+++ b/lib/tasks/poll.rake
@@ -4,7 +4,7 @@ require 'concurrent-ruby'
 
 desc 'Run a polling process to continually monitor servers and meetings'
 task :poll, [:interval] => :environment do |_t, args|
-  args.with_defaults(interval: ENV['POLLING_INTERVAL'])
+  args.with_defaults(interval: 60.seconds)
   interval = args.interval.to_f
   Rails.logger.info("Running poller with interval #{interval}")
 


### PR DESCRIPTION
This change was incorrectly included in #428 and causes the poll
interval to default to 0 when the scalelite poller is launched using a
means other than the provided docker startup script.