### PR TITLE
Allow using server hostname as ID instead of UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `RESPONSE_TIMEOUT`: The timeout to wait for a response after sending a request to the BigBlueButton server in the load balancer and poller in seconds. Default is 10 seconds. Floating point numbers can be used for timeouts less than 1 second.
 * `LOAD_MIN_USER_COUNT`: Minimum user count of a meeting, used for calculating server load. Defaults to 15.
 * `LOAD_JOIN_BUFFER_TIME`: The time(in minutes) until the `LOAD_MIN_USER_COUNT` will be used for calculating server load. Defaults to 15.
+* `SERVER_ID_IS_HOSTNAME`: If set to "true", then instead of generating random UUIDs as the server ID when adding a server Scalelite will use the hostname of the server as the id. Server hostnames will be checked for uniqueness. Defaults to "false".
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/app/models/application_redis_record.rb
+++ b/app/models/application_redis_record.rb
@@ -41,6 +41,17 @@ class ApplicationRedisRecord
     end
   end
 
+  # Raised by the create!, save!, and destroy! methods when the modification was aborted
+  # because of a conflicting concurrent modification. The change should be retried.
+  class ConcurrentModificationError < ApplicationRedisError
+    attr_reader :record
+
+    def initialize(message = nil, record = nil)
+      @record = record
+      super(message)
+    end
+  end
+
   # Initialize a new object. You can optionally pass a hash of attributes to assign.
   def initialize(attributes = {})
     super(attributes)

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -50,28 +50,36 @@ class Server < ApplicationRedisRecord
         clear_attribute_changes([:load])
       end
 
-      server_key = key
-      redis.multi do
-        redis.hset(server_key, 'url', url) if url_changed?
-        redis.hset(server_key, 'secret', secret) if secret_changed?
-        redis.hset(server_key, 'online', online ? 'true' : 'false') if online_changed?
-        redis.hset(server_key, 'load_multiplier', load_multiplier) if load_multiplier_changed?
-        redis.sadd('servers', id) if id_changed?
-        if enabled_changed?
-          if enabled
-            redis.sadd('server_enabled', id)
-          else
-            redis.srem('server_enabled', id)
-            redis.zrem('server_load', id)
+      redis.watch('servers') do
+        exists = redis.sismember('servers', id)
+        raise RecordNotSaved.new("Server already exists with id '#{id}'", self) if id_changed? && exists
+        raise RecordNotSaved.new("Server with id '#{id}' is deleted", self) if !id_changed? && !exists
+
+        server_key = key
+        result = redis.multi do
+          redis.hset(server_key, 'url', url) if url_changed?
+          redis.hset(server_key, 'secret', secret) if secret_changed?
+          redis.hset(server_key, 'online', online ? 'true' : 'false') if online_changed?
+          redis.hset(server_key, 'load_multiplier', load_multiplier) if load_multiplier_changed?
+          redis.sadd('servers', id) if id_changed?
+          if enabled_changed?
+            if enabled
+              redis.sadd('server_enabled', id)
+            else
+              redis.srem('server_enabled', id)
+              redis.zrem('server_load', id)
+            end
+          end
+          if load_changed?
+            if load.present?
+              redis.zadd('server_load', load, id)
+            else
+              redis.zrem('server_load', id)
+            end
           end
         end
-        if load_changed?
-          if load.present?
-            redis.zadd('server_load', load, id)
-          else
-            redis.zrem('server_load', id)
-          end
-        end
+
+        raise ConcurrentModificationError.new('Servers list concurrently modified', self) if result.nil?
       end
     end
 

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -41,6 +41,15 @@ class Server < ApplicationRedisRecord
       raise RecordNotSaved.new('Cannot update id field', self) if id_changed?
 
       # Default values
+      if id.nil?
+        self.id = \
+          if Rails.configuration.x.server_id_is_hostname
+            URI.parse(url).host.downcase(:ascii)
+          else
+            SecureRandom.uuid
+          end
+      end
+
       self.id = SecureRandom.uuid if id.nil?
       self.online = false if online.nil?
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -91,5 +91,8 @@ module Scalelite
 
     # The time(in minutes) until the `load_min_user_count` will be used for calculating server load
     config.x.load_join_buffer_time = ENV.fetch('LOAD_JOIN_BUFFER_TIME', 15).to_i.minutes
+
+    # Whether to generate ids for servers based on the hostname rather than random UUIDs
+    config.x.server_id_is_hostname = ENV['SERVER_ID_IS_HOSTNAME']&.downcase == 'true'
   end
 end


### PR DESCRIPTION
Closes #469 

This is an updated version of #205 that solves the problems that PR had:
* The hostname as id is now checked for uniqueness.
* The setting is off by default for compatibility reasons.