### PR TITLE
add load column to rake status table

### DIFF
--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -20,7 +20,8 @@ task status: :environment do
                         meetings: server.meetings,
                         users: server.users,
                         largest: server.largest_meeting,
-                        videos: server.videos
+                        videos: server.videos,
+                        load: server.load
                       ))
     # Sort list of servers
     servers_info = servers_info.sort_by(&:hostname)
@@ -34,6 +35,7 @@ task status: :environment do
     t.add_column('USERS', &:users)
     t.add_column('LARGEST MEETING', &:largest)
     t.add_column('VIDEOS', &:videos)
+    t.add_column('LOAD', &:load)
   end
 
   puts table.pack


### PR DESCRIPTION
Hi, currently you can't see which server has which current load value - which could differ from the meetings and/or attendee count. This PR adds a "load" column to `rake status`