### PR TITLE
SL-XX: GPG key used for tini fails when building amazonlinux image

### DIFF
--- a/dockerfiles/v1/bionic230-amazonlinux
+++ b/dockerfiles/v1/bionic230-amazonlinux
@@ -24,7 +24,7 @@ FROM amazonlinux AS amazonlinux-base
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-RUN gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
+RUN gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
 RUN gpg --batch --verify /tini.asc /sbin/tini
 RUN chmod +x /sbin/tini
 RUN yum -y install redhat-rpm-config


### PR DESCRIPTION
Tiny needs to be installed from source on amazonlinux. But it turns out that the gpg server used `p80.pool.sks-keyservers.net` is no longer existent.

The end solution would be to add the key to the repo, but for the moment changing the repo to keyserver.ubuntu.com is doing the trick

https://github.com/krallin/tini/issues/124