### PR TITLE
SL-186: Added logic to delete recordings sent to scalelite after a few days

### DIFF
--- a/bigbluebutton/scalelite_cron.sh
+++ b/bigbluebutton/scalelite_cron.sh
@@ -1,0 +1,42 @@
+#!/bin/bash 
+
+# Place this file in /etc/cron.daily
+#
+
+# Delete sent recording after 4 days
+MAXAGE=4
+
+# Delete events files after 4 days
+EVENTS_MAXAGE=4
+
+LOGFILE=/var/log/bigbluebutton/bbb-sender-cleanup.log
+
+shopt -s nullglob
+
+NOW=$(date +%s)
+
+echo "$(date --rfc-3339=seconds) Deleting sent recordings older than ${MAXAGE} days" >>"${LOGFILE}"
+
+# Iterate through the list of recordings for which sender publishing has
+# completed
+for donefile in /var/bigbluebutton/recording/status/published/*-sender.done ; do
+        MTIME=$(stat -c %Y "${donefile}")
+        # Check the age of the recording
+        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $MAXAGE ]; then
+                MEETING_ID=$(basename "${donefile}")
+                MEETING_ID=${MEETING_ID%-sender.done}
+                echo "${MEETING_ID}" >> "${LOGFILE}"
+
+                bbb-record --delete "${MEETING_ID}" >> "${LOGFILE}"
+        fi
+done
+
+echo "$(date --rfc-3339=seconds) Deleting events files older than ${EVENTS_MAXAGE}"
+for eventsfile in /var/bigbluebutton/events/*/events.xml ; do
+        MTIME=$(stat -c %Y "${eventsfile}")
+        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $EVENTS_MAXAGE ]; then
+                EVENTS_DIR="${eventsfile%/*}"
+                rm -rv "${EVENTS_DIR}" >>"${LOGFILE}" 2>&1
+        fi
+done
+

--- a/bigbluebutton/scalelite_post_publish.rb
+++ b/bigbluebutton/scalelite_post_publish.rb
@@ -40,6 +40,8 @@ end
 
 props = Psych.load_file(File.join(__dir__, '../bigbluebutton.yml'))
 published_dir = props['published_dir'] || raise('Unable to determine published_dir from bigbluebutton.yml')
+recording_dir = props['recording_dir'] || raise('Unable to determine recording_dir from bigbluebutton.yml')
+
 scalelite_props = Psych.load_file(File.join(__dir__, '../scalelite.yml'))
 work_dir = scalelite_props['work_dir'] || raise('Unable to determine work_dir from scalelite.yml')
 spool_dir = scalelite_props['spool_dir'] || raise('Unable to determine spool_dir from scalelite.yml')
@@ -71,6 +73,11 @@ begin
   puts("Transferring recording archive to #{spool_dir}")
   system('rsync', '--verbose', '--protect-args', *extra_rsync_opts, archive_file, spool_dir) \
     || raise('Failed to transfer recording archive')
+
+  puts('Create sender.done file')
+  File.open("#{recording_dir}/status/published/#{meeting_id}-sender.done", 'w') do |f|
+    f.write("Published #{meeting_id}")
+  end
 
   puts('Recording transferring to Scalelite ends')
 ensure


### PR DESCRIPTION
This pull request adds a cron.daily job to delete sent recordings from the BigBlueButton server after 4 days.