### PR TITLE
SL-187:  Fix getRecordings() Redirect Issue

### DIFF
--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -31,7 +31,7 @@ xml.response do
           recording.playback_formats.each do |format|
             xml.format do
               xml.type format.format
-              xml.url "#{@url_prefix}#{format.url}"
+              xml.url "#{@url_prefix}#{format.url}/"
               xml.length format.length
               xml.processingTime format.processing_time unless format.processing_time.nil?
               unless format.thumbnails.empty?

--- a/test/controllers/bigbluebutton_api_controller_test.rb
+++ b/test/controllers/bigbluebutton_api_controller_test.rb
@@ -966,7 +966,7 @@ class BigBlueButtonApiControllerTest < ActionDispatch::IntegrationTest
           end
 
           assert_select format_el, 'type', pf.format
-          assert_select format_el, 'url', "#{url_prefix}#{pf.url}"
+          assert_select format_el, 'url', "#{url_prefix}#{pf.url}/"
           assert_select format_el, 'length', pf.length.to_s
           assert_select format_el, 'processingTime', pf.processing_time.to_s
 


### PR DESCRIPTION
The issue is that going to the url of the recorded meeting from getRecordings() returns a 301 redirect that is non-https which violates the client's IT policy