### PR TITLE
SL-188: Prevent get_recordings api from returning all recordings when recordID not specified in the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `JOIN_EXCLUDE_PARAMS`: List of BBB server attributes that should not be modified by join API call. Should be in the format 'JOIN_EXCLUDE_PARAMS="param1,param2,param3"'.
 * `PREPARED_STATEMENT`: Enable/Disable Active Record prepared statements feature, can be disabled by setting the value as `false`. Defaults to `true`.
 * `DB_CONNECTION_RETRY_COUNT`: The number of times db connection retries will be attempted, in case of a db connection failure. Defaults to `3`
+* `GET_RECORDINGS_API_FILTERED`: Prevent get_recordings api from returning all recordings when recordID is not specified in the request, by setting value to 'true'. Defaults to false.
 
 ### Redis Connection (`config/redis_store.yml`)
 

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -266,6 +266,7 @@ class BigBlueButtonApiController < ApplicationController
   end
 
   def get_recordings
+    params.require(:recordID) if Rails.configuration.x.get_recordings_api_filtered
     query = Recording.includes(playback_formats: [:thumbnails], metadata: []).references(:metadata)
     query = query.where(state: params[:state].split(',')) if params[:state].present?
     meta_params = params.select { |key, _value| key.to_s.match(/^meta_/) }.permit!.to_h.to_a

--- a/config/application.rb
+++ b/config/application.rb
@@ -111,5 +111,9 @@ module Scalelite
 
     # DB connection retry attempt counts
     config.x.db_connection_retry_count = ENV.fetch('DB_CONNECTION_RETRY_COUNT', '3').to_i
+
+    # Prevents get_recordings api from returning all recordings when recordID is not specified in the request, if set to 'true'.
+    # Defaults to false.
+    config.x.get_recordings_api_filtered = ENV.fetch('GET_RECORDINGS_API_FILTERED', 'false').casecmp?('true')
   end
 end


### PR DESCRIPTION
Prevent get_recordings api from returning all recordings when recordID not specified in the request