### PR TITLE
Use original_fullpath when generating recording resource internal URL

### DIFF
--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -34,7 +34,7 @@ class PlaybackController < ApplicationController
   def deliver_resource(permit)
     raise RecordingNotFoundError unless permit
 
-    resource_path = request.fullpath
+    resource_path = request.original_fullpath
     static_resource_path = "/static-resource#{resource_path}"
     response.headers['X-Accel-Redirect'] = static_resource_path
     head(:ok)


### PR DESCRIPTION
Rails does normalization on the URL that can remove the trailing / in
cases where we need to preserve it. The `original_` prefixed version
does not have that normalization applied.