### PR TITLE
Protected recordings updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ Layout/HashAlignment:
   EnforcedColonStyle: [ key, table ]
 Layout/LineLength:
   Max: 128
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
 Metrics:
   Enabled: false
 Naming/AccessorMethodName:

--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `PREPARED_STATEMENT`: Enable/Disable Active Record prepared statements feature, can be disabled by setting the value as `false`. Defaults to `true`.
 * `DB_CONNECTION_RETRY_COUNT`: The number of times db connection retries will be attempted, in case of a db connection failure. Defaults to `3`.
 * `RECORDING_PLAYBACK_FORMATS`: Recording playback formats supported by Scalelite, defaults to `presentation:video:podcast:notes:capture`.
-* `PROTECTED_RECORDINGS_ENABLED`: Recordings will proctected, if set to 'true'. Defaults to `false`.
-* `PROTECTED_RECORDINGS_TIMEOUT`: Protected recordings url expiry timeout in hours. Defaults to `6`.
+* `PROTECTED_RECORDINGS_ENABLED`: Recordings links will be protected if set to 'true'. Defaults to `false`.
+* `PROTECTED_RECORDINGS_TOKEN_TIMEOUT`: Protected recording link token timeout in minutes. This is the amount of time that the one-time-use link returned in `getRecordings` calls will be valid for. Defaults to 60 minutes (1 hour).
+* `PROTECTED_RECORDINGS_TIMEOUT`: Protected recordings resource access cookie timeout in minutes. This is the amount of time that a user will be granted access to view a recording for after clicking on the one-time-use link. Defaults to 360 minutes (6 hours).
 
 ### Redis Connection (`config/redis_store.yml`)
 
@@ -257,7 +258,7 @@ Mark the server as disabled.
 When a server is disabled, no new meetings will be started on the server.
 You will not be able to join existing meetings.
 The Poll process does not update disabled servers.
-You should not disable a server if it has active load, you can either use the cordon option to drain the server or respond with `yes` to clear all meeting state.  
+You should not disable a server if it has active load, you can either use the cordon option to drain the server or respond with `yes` to clear all meeting state.
 
 ### Enable a server
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Metal
   include ActionController::ConditionalGet
   include ActionController::ImplicitRender
   include ActionController::StrongParameters
+  include ActionController::Cookies
 
   include ActionController::ForceSSL
   include ActionController::DataStreaming

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,8 +43,6 @@ class ApplicationController < ActionController::Metal
     render(xml: build_error(error.message_key, error.message))
   end
 
-  rescue_from RecordingNotFoundError, with: :render_recording_not_found
-
   private
 
   # Generic XML builder for errors
@@ -56,9 +54,5 @@ class ApplicationController < ActionController::Metal
         xml.message(message)
       end
     end
-  end
-
-  def render_recording_not_found
-    render(file: Rails.root.join('/public/recording_not_found.html'), status: :not_found)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,32 +1,6 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::Metal
-  # These includes are based on ActionController::API but with the full rendering stack re-enabled
-  include AbstractController::Rendering
-
-  include ActionController::UrlFor
-  include ActionController::Redirecting
-  include ActionView::Layouts
-  include ActionController::Rendering
-  include ActionController::Renderers::All
-  include ActionController::ConditionalGet
-  include ActionController::ImplicitRender
-  include ActionController::StrongParameters
-  include ActionController::Cookies
-
-  include ActionController::ForceSSL
-  include ActionController::DataStreaming
-  include ActionController::DefaultHeaders
-
-  include AbstractController::Callbacks
-  include ActionController::Rescue
-  include ActionController::Instrumentation
-  include ActionController::ParamsWrapper
-
-  ActiveSupport.run_load_hooks(:action_controller_api, self)
-  ActiveSupport.run_load_hooks(:action_controller, self)
-  # Controller setup done, applications stuff is below
-
+class ApplicationController < ActionController::Base
   include BBBErrors
 
   rescue_from BBBError do |e|

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -432,9 +432,8 @@ class BigBlueButtonApiController < ApplicationController
   # Filter out unneeded params when passing through to join and create calls
   # Has to be to_unsafe_hash since to_h only accepts permitted attributes
   def pass_through_params(excluded_params)
-    params.except(*(excluded_params +
-    [:format, :controller, :action, :checksum]))
-          .to_unsafe_hash
+    params.except(*(excluded_params + [:format, :controller, :action, :checksum]))
+      .to_unsafe_hash
   end
 
   # Success response if there are no meetings on any servers

--- a/app/controllers/concerns/bbb_errors.rb
+++ b/app/controllers/concerns/bbb_errors.rb
@@ -52,7 +52,4 @@ module BBBErrors
       super('serverUnavailable', 'The server for this meeting is disabled/offline.')
     end
   end
-
-  class RecordingNotFoundError < StandardError
-  end
 end

--- a/app/controllers/concerns/cookie_same_site_compat.rb
+++ b/app/controllers/concerns/cookie_same_site_compat.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module CookieSameSiteCompat
+  extend ActiveSupport::Concern
+
+  def cookie_same_site_none(useragent)
+    cookie_same_site_none_incompatible?(useragent) ? :nil : :none
+  end
+
+  def cookie_same_site_none_incompatible?(useragent)
+    webkit_same_site_bug?(useragent) || drops_unrecognized_same_site_cookies?(useragent)
+  end
+
+  private
+
+  IOS_VERSION_REGEXP = %r{\(iP.+; CPU .*OS (\d+)[_\d]*.*\) AppleWebKit/}.freeze
+  MACOS_VERSION_REGEXP = %r{\(Macintosh;.*Mac OS X (\d+)_(\d+)[_\d]*.*\) AppleWebKit/}.freeze
+  SAFARI_REGEXP = %r{Version/.* Safari/}.freeze
+  CHROMIUM_BASED_REGEXP = /Chrom(?:e|ium)/.freeze
+  CHROMIUM_VERSION_REGEXP = %r{Chrom[^ /]+/(\d+)[.\d]* }.freeze
+  MAC_EMBEDDED_REGEXP = %r{^Mozilla/[.\d]+ \(Macintosh;.*Mac OS X [_\d]+\) AppleWebKit/[.\d]+ \(KHTML, like Gecko\)$}.freeze
+  UC_BROWSER_REGEXP = %r{UCBrowser/}.freeze
+  UC_BROWSER_VERSION_REGEXP = %r{UCBrowser/(\d+)\.(\d+)\.(\d+)[.\d]* }.freeze
+
+  def webkit_same_site_bug?(useragent)
+    return true if ios_version?(12, useragent)
+
+    if macos_version?(10, 14, useragent)
+      return true if SAFARI_REGEXP.match?(useragent) && !CHROMIUM_BASED_REGEXP.match(useragent)
+      return true if MAC_EMBEDDED_REGEXP.match?(useragent)
+    end
+
+    false
+  end
+
+  def ios_version?(major, useragent)
+    IOS_VERSION_REGEXP.match(useragent) do |ios_version|
+      return true if ios_version[1].to_i == major
+    end
+
+    false
+  end
+
+  def macos_version?(major, minor, useragent)
+    MACOS_VERSION_REGEXP.match(useragent) do |macos_version|
+      return true if macos_version[1].to_i == major && macos_version[2].to_i == minor
+    end
+
+    false
+  end
+
+  def drops_unrecognized_same_site_cookies?(useragent)
+    return !uc_browser_version_at_least?(12, 13, 2, useragent) if uc_browser?(useragent)
+    return chromium_version_in?(51...67, useragent) if chromium_based?(useragent)
+
+    false
+  end
+
+  def chromium_based?(useragent)
+    CHROMIUM_BASED_REGEXP.match?(useragent)
+  end
+
+  def chromium_version_in?(range, useragent)
+    CHROMIUM_VERSION_REGEXP.match(useragent) do |chromium_version|
+      return range.include?(chromium_version[1].to_i)
+    end
+
+    false
+  end
+
+  def uc_browser?(useragent)
+    UC_BROWSER_REGEXP.match?(useragent)
+  end
+
+  def uc_browser_version_at_least?(major, minor, build, useragent)
+    UC_BROWSER_VERSION_REGEXP.match(useragent) do |uc_version|
+      major_version = uc_version[1].to_i
+      minor_version = uc_version[2].to_i
+      build_version = uc_version[3].to_i
+      return major_version > major if major_version != major
+      return minor_version > minor if minor_Version != minor
+
+      return build_version >= build
+    end
+
+    false
+  end
+end

--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -96,6 +96,6 @@ class PlaybackController < ApplicationController
   end
 
   def recording_not_found
-    render(file: Rails.root.join('/public/recording_not_found.html'), status: :not_found)
+    render(file: Rails.root.join('public/recording_not_found.html'), status: :not_found)
   end
 end

--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -43,7 +43,7 @@ class PlaybackController < ApplicationController
 
   def create_cookie
     resource_path = "/#{@playback_format.format}/#{@recording.record_id}"
-    expires = Time.to_i + Rails.configuration.x.recording_cookie_ttl
+    expires = Time.now.to_i + Rails.configuration.x.recording_cookie_ttl
     payload = {
       'sub' => resource_path,
       'exp' => expires,

--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -1,42 +1,96 @@
 # frozen_string_literal: true
 
 class PlaybackController < ApplicationController
-  include ApiHelper
+  include CookieSameSiteCompat
+
+  class RecordingNotFoundError < StandardError
+  end
+
+  rescue_from ActiveRecord::RecordNotFound, RecordingNotFoundError, with: :recording_not_found
+
   def play
-    recording = Recording.find_by(record_id: playback_params[:record_id])
-    raise RecordingNotFoundError if recording.nil?
+    @playback_format = PlaybackFormat
+      .includes(:recording)
+      .find_by!(format: params[:playback_format], recording: { record_id: params[:record_id] })
+    @recording = @playback_format.recording
 
     if recording.protected
-      begin
-        raise RecordingNotFoundError if params[:token].blank?
-
-        permit = recording.validate_token(params[:token])
-        deliver_resource(permit)
-      rescue JWT::DecodeError
-        deliver_resource(false)
+      # Consume the one-time-use token (return an error if missing/invalid)
+      payload = PlaybackFormat.consume_protector_token(params[:token])
+      if payload['record_id'] != @recording.record_id || payload['format'] != @playback_format.format
+        raise RecordingNotFoundError
       end
-    else
-      # If recording isn't protected, don't check tokens
-      deliver_resource(true)
+
+      # Set the cookie that will provide access to resources for this recording & playback format
+      create_cookie
     end
+
+    redirect_to(@playback_format.url, status: :temporary_redirect)
   end
 
   def resource
-    deliver_resource(true)
+    @playback_format = PlaybackFormat
+      .includes(:recording)
+      .find_by!(format: params[:playback_format], recording: { record_id: params[:record_id] })
+    @recording = @playback_format.recording
+
+    verify_cookie if @recording.protected
+
+    deliver_resource
   end
 
   private
 
-  def playback_params
-    params.permit(:playback_format, :player_version, :record_id, :meetingId, :token)
+  def create_cookie
+    resource_path = "/#{@playback_format.format}/#{@recording.record_id}"
+    expires = Time.to_i + Rails.configuration.x.recording_cookie_ttl
+    payload = {
+      'sub' => resource_path,
+      'exp' => expires,
+    }
+    secret = Rails.application.secrets.secret_key_base
+    token = JWT.encode(payload, secret, 'HS256')
+
+    cookies[cookie_name] = {
+      value: token,
+      path: resource_path,
+      secure: true,
+      httponly: true,
+      same_site: cookie_same_site_none(request.user_agent),
+    }
   end
 
-  def deliver_resource(permit)
-    raise RecordingNotFoundError unless permit
+  def verify_cookie
+    cookie = cookies[cookie_name]
+    raise RecordingNotFoundError if cookie.blank?
 
+    resource_path = "/#{@playback_format.format}/#{@recording.record_id}"
+    secret = Rails.application.secrets.secret_key_base
+    JWT.decode(
+      cookie,
+      secret,
+      true,
+      'sub' => resource_path,
+      required_claims: %w[sub exp],
+      verify_sub: true,
+      algorithm: 'HS256'
+    )
+  rescue JWT::DecodeError
+    raise RecordingNotFoundError
+  end
+
+  def cookie_name
+    "recording_#{@playback_format.format}_#{@recording.record_id}"
+  end
+
+  def deliver_resource
     resource_path = request.original_fullpath
     static_resource_path = "/static-resource#{resource_path}"
     response.headers['X-Accel-Redirect'] = static_resource_path
     head(:ok)
+  end
+
+  def recording_not_found
+    render(file: Rails.root.join('/public/recording_not_found.html'), status: :not_found)
   end
 end

--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -6,7 +6,12 @@ class PlaybackController < ApplicationController
   class RecordingNotFoundError < StandardError
   end
 
-  rescue_from ActiveRecord::RecordNotFound, RecordingNotFoundError, with: :recording_not_found
+  rescue_from(
+    ActiveRecord::RecordNotFound,
+    RecordingNotFoundError,
+    PlaybackFormat::ProtectorTokenError,
+    with: :recording_not_found
+  )
 
   def play
     @playback_format = PlaybackFormat

--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -10,11 +10,11 @@ class PlaybackController < ApplicationController
 
   def play
     @playback_format = PlaybackFormat
-      .includes(:recording)
-      .find_by!(format: params[:playback_format], recording: { record_id: params[:record_id] })
+      .joins(:recording)
+      .find_by!(format: params[:playback_format], recordings: { record_id: params[:record_id] })
     @recording = @playback_format.recording
 
-    if recording.protected
+    if @recording.protected
       # Consume the one-time-use token (return an error if missing/invalid)
       payload = PlaybackFormat.consume_protector_token(params[:token])
       if payload['record_id'] != @recording.record_id || payload['format'] != @playback_format.format
@@ -30,8 +30,8 @@ class PlaybackController < ApplicationController
 
   def resource
     @playback_format = PlaybackFormat
-      .includes(:recording)
-      .find_by!(format: params[:playback_format], recording: { record_id: params[:record_id] })
+      .joins(:recording)
+      .find_by!(format: params[:playback_format], recordings: { record_id: params[:record_id] })
     @recording = @playback_format.recording
 
     verify_cookie if @recording.protected

--- a/app/helpers/bigbluebutton_api_helper.rb
+++ b/app/helpers/bigbluebutton_api_helper.rb
@@ -4,16 +4,15 @@ module BigBlueButtonApiHelper
   require 'uri'
   include ApiHelper
 
-  def self.recording_url(recording, url_prefix, format_url)
-    if recording.protected
-      token = recording.generate_token
-      url = url_prefix + format_url
-      uri = ::URI.parse(url)
-      params = Hash[URI.decode_www_form(uri.query || '')].merge(token: token)
-      uri.query = URI.encode_www_form(params)
-      uri.to_s
-    else
-      "#{url_prefix}#{format_url}"
-    end
+  def self.recording_url(playback_format, url_prefix)
+    recording = playback_format.recording
+    url = "#{url_prefix}#{playback_format.url}"
+    return url unless recording.protected
+
+    token = playback_format.create_protector_token
+    uri = URI.parse(url)
+    params = Hash[URI.decode_www_form(uri.query || '')].merge(token: token)
+    uri.query = URI.encode_www_form(params)
+    uri.to_s
   end
 end

--- a/app/helpers/bigbluebutton_api_helper.rb
+++ b/app/helpers/bigbluebutton_api_helper.rb
@@ -1,16 +1,5 @@
 # frozen_string_literal: true
 
 module BigBlueButtonApiHelper
-  require 'uri'
   include ApiHelper
-
-  def self.recording_url(playback_format, url_prefix)
-    recording = playback_format.recording
-    unless recording.protected
-      return url_prefix + playback_play_path(record_id: recording.record_id, playback_format: playback_format.format)
-    end
-
-    token = playback_format.create_protector_token
-    url_prefix + playback_play_path(record_id: recording.record_id, playback_format: playback_format.format, token: token)
-  end
 end

--- a/app/helpers/bigbluebutton_api_helper.rb
+++ b/app/helpers/bigbluebutton_api_helper.rb
@@ -6,13 +6,11 @@ module BigBlueButtonApiHelper
 
   def self.recording_url(playback_format, url_prefix)
     recording = playback_format.recording
-    url = "#{url_prefix}#{playback_format.url}"
-    return url unless recording.protected
+    unless recording.protected
+      return url_prefix + playback_play_path(record_id: recording.record_id, playback_format: playback_format.format)
+    end
 
     token = playback_format.create_protector_token
-    uri = URI.parse(url)
-    params = Hash[URI.decode_www_form(uri.query || '')].merge(token: token)
-    uri.query = URI.encode_www_form(params)
-    uri.to_s
+    url_prefix + playback_play_path(record_id: recording.record_id, playback_format: playback_format.format, token: token)
   end
 end

--- a/app/models/playback_format.rb
+++ b/app/models/playback_format.rb
@@ -13,8 +13,8 @@ class PlaybackFormat < ApplicationRecord
   def create_protector_token
     token = SecureRandom.hex(32)
     payload = {
-      'record_id' => playback_format.recording.record_id,
-      'format' => playback_format.format,
+      'record_id' => recording.record_id,
+      'format' => self.format,
     }.to_json
 
     key = "#{PROTECTOR_TOKEN_KEY_PREFIX}#{token}"

--- a/app/models/playback_format.rb
+++ b/app/models/playback_format.rb
@@ -4,4 +4,41 @@ class PlaybackFormat < ApplicationRecord
   belongs_to :recording
   has_many :thumbnails, dependent: :destroy
   default_scope { order(format: :asc) }
+
+  class ProtectorTokenError < RuntimeError; end
+
+  PROTECTOR_TOKEN_KEY_PREFIX = 'protector_token_'
+
+  # Create a one-time-use protection token for this playback format
+  def create_protector_token
+    token = SecureRandom.hex(32)
+    payload = {
+      'record_id' => playback_format.recording.record_id,
+      'format' => playback_format.format,
+    }.to_json
+
+    key = "#{PROTECTOR_TOKEN_KEY_PREFIX}#{token}"
+    RedisStore.with_connection do |redis|
+      redis.multi do
+        redis.set(key, payload)
+        redis.expire(key, Rails.configuration.x.recording_token_ttl)
+      end
+    end
+  end
+
+  # Lookup and invalidate a one-time-use protection token, and return the playback format it is for
+  def self.consume_protector_token(token)
+    raise ProtectorTokenError, 'Token format is invalid' if token.blank? || !/\A[0-9a-f]{64}\z/.match?(token)
+
+    key = "#{PROTECTOR_TOKEN_KEY_PREFIX}#{token}"
+    result = RedisStore.with_connection do |redis|
+      redis.multi do
+        redis.get(key)
+        redis.del(key)
+      end
+    end
+    raise ProtectorTokenError, 'Token not found' if result[0].blank?
+
+    JSON.parse(result[0])
+  end
 end

--- a/app/models/playback_format.rb
+++ b/app/models/playback_format.rb
@@ -24,6 +24,8 @@ class PlaybackFormat < ApplicationRecord
         redis.expire(key, Rails.configuration.x.recording_token_ttl)
       end
     end
+
+    token
   end
 
   # Lookup and invalidate a one-time-use protection token, and return the playback format it is for

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -115,30 +115,4 @@ class Recording < ApplicationRecord
       retry
     end
   end
-
-  def generate_token
-    exp = Rails.configuration.x.protected_recordings_timeout.hours.from_now.to_i
-    payload = { exp: exp }
-    token = encoded_token(payload)
-    tokens.create(token: token)
-    token
-  end
-
-  def validate_token(token)
-    recording_tokens = tokens.where(token: token).destroy_all.pluck(:token)
-    decoded_token(token)
-    recording_tokens.include?(token)
-  end
-
-  private
-
-  def encoded_token(payload)
-    secret = Rails.configuration.x.loadbalancer_secrets[0]
-    JWT.encode(payload, secret, 'HS256')
-  end
-
-  def decoded_token(token)
-    secret = Rails.configuration.x.loadbalancer_secrets[0]
-    JWT.decode(token, secret, 'HS256')[0]
-  end
 end

--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -32,7 +32,7 @@ xml.response do
           recording.playback_formats.each do |format|
             xml.format do
               xml.type format.format
-              xml.url BigBlueButtonApiHelper.recording_url(recording, @url_prefix, format.url)
+              xml.url BigBlueButtonApiHelper.recording_url(format, @url_prefix)
               xml.length format.length
               xml.processingTime format.processing_time unless format.processing_time.nil?
               unless format.thumbnails.empty?

--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -33,7 +33,11 @@ xml.response do
             xml.format do
               xml.type format.format
               if recording.protected
-                xml.url @url_prefix + playback_play_path(record_id: recording.record_id, playback_format: format.format, token: format.create_protector_token)
+                xml.url @url_prefix + playback_play_path(
+                  record_id: recording.record_id,
+                  layback_format: format.format,
+                  token: format.create_protector_token
+                )
               else
                 xml.url @url_prefix + playback_format.url
               end

--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -35,7 +35,7 @@ xml.response do
               if recording.protected
                 xml.url @url_prefix + playback_play_path(
                   record_id: recording.record_id,
-                  layback_format: format.format,
+                  playback_format: format.format,
                   token: format.create_protector_token
                 )
               else

--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -39,7 +39,7 @@ xml.response do
                   token: format.create_protector_token
                 )
               else
-                xml.url @url_prefix + playback_format.url
+                xml.url @url_prefix + format.url
               end
               xml.length format.length
               xml.processingTime format.processing_time unless format.processing_time.nil?

--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -32,7 +32,11 @@ xml.response do
           recording.playback_formats.each do |format|
             xml.format do
               xml.type format.format
-              xml.url BigBlueButtonApiHelper.recording_url(format, @url_prefix)
+              if recording.protected
+                xml.url @url_prefix + playback_play_path(record_id: recording.record_id, playback_format: format.format, token: format.create_protector_token)
+              else
+                xml.url @url_prefix + playback_format.url
+              end
               xml.length format.length
               xml.processingTime format.processing_time unless format.processing_time.nil?
               unless format.thumbnails.empty?

--- a/config/application.rb
+++ b/config/application.rb
@@ -118,8 +118,9 @@ module Scalelite
 
     # Recordings will proctected, if set to 'true'. Defaults to false.
     config.x.protected_recordings_enabled = ENV.fetch('PROTECTED_RECORDINGS_ENABLED', 'false').casecmp?('true')
-
-    # Protected recordings url expiry timeout in hours. Defaults to 6.
-    config.x.protected_recordings_timeout = ENV.fetch('PROTECTED_RECORDINGS_TIMEOUT', '6').to_i
+    # Protected recordings token timeout in minutes. Defaults to 60 (1 hour)
+    config.x.recording_token_ttl = ENV.fetch('PROTECTED_RECORDINGS_TOKEN_TIMEOUT', '60').to_i.minutes
+    # Protected recordings resource access cookie timeout in minutes. Defaults to 360 (6 hours)
+    config.x.recording_cookie_ttl = ENV.fetch('PROTECTED_RECORDINGS_TIMEOUT', '360').to_i.minutes
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,11 +33,6 @@ module Scalelite
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
-
     # Read the file config/redis_store.yml as per-environment configuration with erb
     config.x.redis_store = config_for(:redis_store)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,17 +31,16 @@ Rails.application.routes.draw do
 
   get('health_check', to: 'health_check#index')
 
-  get('playback/:playback_format/:player_version/:record_id', to: 'playback#play',
-                                                              format: false, as: :playback,
-                                                              constraints: { player_version: %r{[^\/]+} })
-  get('playback/:playback_format/:player_version(/*resource)', to: 'playback#resource', format: false,
-                                                               as: :playback_player,
-                                                               constraints: { player_version: %r{[^\/]+} })
-
-  Rails.configuration.x.recording_playback_formats.each do |playback_format|
-    get("recording/:#{playback_format}/:record_id", to: 'playback#play', format: false)
-    get("#{playback_format}/:record_id", to: 'playback#play', format: false)
-    get("#{playback_format}(/*playback_resource)", to: 'playback#resource', format: false)
+  unless Rails.configuration.x.recording_disabled
+    get('recording/:record_id/:playback_format', to: 'playback#play', format: false, as: :playback_play)
+    Rails.configuration.x.recording_playback_formats.each do |playback_format|
+      get(
+        "#{playback_format}/:record_id(/*resource)",
+        to: 'playback#resource',
+        format: false,
+        defaults: { playback_format: playback_format }
+      )
+    end
   end
 
   match '*any', via: :all, to: 'errors#unsupported_request'


### PR DESCRIPTION
Rewrite the protected recordings implementation to store one-time-use tokens in redis, and use cookies to handle access control to subresources.

The nginx configuration for this updated setup should have location blocks set up like this:

```
        ## Disable hidden files except .well-known
        location ~  /\.(?!well-known).* {
                deny all;
                access_log off;
                log_not_found off;
                return 404;
        }

        location /health_check {
                proxy_pass http://docker-scalelite-api;
                include /etc/nginx/sites-common;
        }

        location / {
                proxy_pass http://docker-scalelite-api;
                include /etc/nginx/sites-common;
        }

        location /static-resource/ {
                proxy_pass http://docker-scalelite-recordings/;
                include /etc/nginx/sites-common;
                internal;
        }

        location /playback {
                proxy_pass http://docker-scalelite-recordings/;
                include /etc/nginx/sites-common;
        }
```