### PR TITLE
SL-196: fix(poll) add dependency to fix DNS resolution timeout bug.

### DIFF
--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -2,6 +2,9 @@
 
 require 'net/http'
 
+# The following is necessary to fix a DNS resolution timeout bug see https://github.com/ruby/ruby/pull/597#issuecomment-40507119
+require 'resolv-replace'
+
 module ApiHelper
   extend ActiveSupport::Concern
   include BBBErrors


### PR DESCRIPTION
Prevents polling task from raising unwanted "execution expired" errors which lead to servers being falsely detected as "offline" and eventually panicked. (see file lib/tasks/poll.rake lines 89-104)

Fixes issue reported on Stackoverflow : https://stackoverflow.com/questions/9939726/ruby-net-http-opening-connection-very-slow/27485369#27485369