### PR TITLE
SL-200: Response to protected recordings is not backward compatible

### DIFF
--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -20,6 +20,10 @@ class Recording < ApplicationRecord
     where(query_string, *rid_prefixes)
   end
 
+  def protected
+    self[:protected] || false
+  end
+
   # Create a new recording (and recursively playback format, meta, thumbnails) from a BigBlueButton metadata.xml
   def self.create_from_metadata_xml(metadata, overrides = {})
     metadata_xml = Nokogiri::XML(metadata)


### PR DESCRIPTION
After the migration the migrated recordings have protected=nil. The response should be the same as if it was false.

<protected>false</protected>

instead it responds

<protected/>

