### PR TITLE
SL- 209: Fix db:migrate task and auto-bootstrap DB in bin/start

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+db_create="$(bundle exec rake db:create 2>&1)"
+
+if [ -z "${db_create##*already exists*}" ]; then
+  echo ">>> Database migration"
+  bundle exec rake db:migrate
+else
+  echo ">>> Database initialization"
+  bundle exec rake db:schema:load
+fi
+
 exec tini -- bundle exec puma -C config/puma.rb "$@"

--- a/db/migrate/20181123180008_init.rb
+++ b/db/migrate/20181123180008_init.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/CreateTableWithTimestamps
+
+class Init < ActiveRecord::Migration[6.0]
+  def change
+    create_table :metadata, force: :cascade do |t|
+      t.bigint(:recording_id)
+      t.string(:key)
+      t.string(:value)
+      t.index(%w[recording_id key], name: 'index_metadata_on_recording_id_and_key', unique: true)
+    end
+
+    create_table :playback_formats, force: :cascade do |t|
+      t.bigint(:recording_id)
+      t.string(:format)
+      t.string(:url)
+      t.integer(:length)
+      t.integer(:processing_time)
+      t.index(%w[recording_id format], name: 'index_playback_formats_on_recording_id_and_format', unique: true)
+    end
+
+    create_table :recordings, force: :cascade do |t|
+      t.string(:record_id)
+      t.string(:meeting_id)
+      t.string(:name)
+      t.boolean(:published)
+      t.integer(:participants)
+      t.string(:state)
+      t.datetime(:starttime)
+      t.datetime(:endtime)
+      t.datetime(:deleted_at)
+      t.index(%w[meeting_id], name: 'index_recordings_on_meeting_id')
+      t.index(%w[record_id], name: 'index_recordings_on_record_id', unique: true)
+    end
+
+    create_table :thumbnails, force: :cascade do |t|
+      t.bigint(:playback_format_id)
+      t.integer(:width)
+      t.integer(:height)
+      t.string(:alt)
+      t.string(:url)
+      t.integer(:sequence)
+      t.index(%w[playback_format_id], name: 'index_thumbnails_on_playback_format_id')
+    end
+  end
+end
+
+# rubocop:enable Rails/CreateTableWithTimestamps


### PR DESCRIPTION
This adds a missing DB migration step and ensures that 'db:migrate'
on an existing but empty DB works as expected. The bin/start script,
which is used as a docker container entry point, now bootstraps or
migrates the DB on startup (inspired by greenlight).