### PR TITLE
SL-214: patch for fixing scalelite-nginx recording backward compatibility #686

### DIFF
--- a/nginx/conf.d/scalelite.common
+++ b/nginx/conf.d/scalelite.common
@@ -5,6 +5,19 @@ location /static-resource {
   internal;
 }
 
+location /playback/presentation/playback.html {
+  return 301 /playback/presentation/0.81/playback.html?$query_string;
+  # If you have recordings from 0.9.0 beta versions and are sure
+  # that you will never want to play recordings made with
+  # BigBlueButton 0.81, comment the line above and uncomment the
+  # following line:
+  #return 301 /playback/presentation/0.9.0/playback.html?$query_string;
+}
+
+location /playback/presentation/2.0/playback.html {
+  return 301 /playback/presentation/2.3/$arg_meetingId?$query_string;
+}
+
 location /playback {
   root /var/bigbluebutton;
   try_files $uri /playback/presentation/2.3/index.html;


### PR DESCRIPTION
## Description
scalelite-nginx fails to respond to old recordings. 

## Testing Steps
Update deployment based on systemd with the new scalelite-nginx image. Old recordings created with a BBB server 2.0 or earlier, should now be played back.