### PR TITLE
SL-216: added support for SHA256 slong SHA1 for API request 'signatures' #221

### DIFF
--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -9,11 +9,13 @@ module ApiHelper
   extend ActiveSupport::Concern
   include BBBErrors
 
-  CHECKSUM_LENGTH = 40
+  CHECKSUM_LENGTH_SHA1 = 40
+  CHECKSUM_LENGTH_SHA256 = 64
 
   # Verify checksum
   def verify_checksum
-    raise ChecksumError unless params[:checksum].present? && params[:checksum].length == CHECKSUM_LENGTH
+    raise ChecksumError unless params[:checksum].present? &&
+                               (params[:checksum].length == CHECKSUM_LENGTH_SHA1 || params[:checksum].length == CHECKSUM_LENGTH_SHA256)
 
     # Camel case (ex) get_meetings to getMeetings to match BBB server
     check_string = action_name.camelcase(:lower)
@@ -22,8 +24,10 @@ module ApiHelper
     )
 
     return if Rails.configuration.x.loadbalancer_secrets.any? do |secret|
-      checksum = Digest::SHA1.hexdigest(check_string + secret)
-      ActiveSupport::SecurityUtils.fixed_length_secure_compare(checksum, params[:checksum])
+      checksum_sha1 = Digest::SHA1.hexdigest(check_string + secret)
+      checksum_sha256 = Digest::SHA256.hexdigest(check_string + secret)
+      ActiveSupport::SecurityUtils.secure_compare(checksum_sha1, params[:checksum]) ||
+      ActiveSupport::SecurityUtils.secure_compare(checksum_sha256, params[:checksum])
     end
 
     raise ChecksumError
@@ -34,7 +38,7 @@ module ApiHelper
     # Add slash at the end if its not there
     base_uri += '/' unless base_uri.ends_with?('/')
     check_string = URI.encode_www_form(bbb_params)
-    checksum = Digest::SHA1.hexdigest(action + check_string + secret)
+    checksum = Digest::SHA256.hexdigest(action + check_string + secret)
     uri = URI.join(base_uri, action)
     uri.query = URI.encode_www_form(bbb_params.merge(checksum: checksum))
     uri

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -15,7 +15,8 @@ module ApiHelper
   # Verify checksum
   def verify_checksum
     raise ChecksumError unless params[:checksum].present? &&
-                               (params[:checksum].length == CHECKSUM_LENGTH_SHA1 || params[:checksum].length == CHECKSUM_LENGTH_SHA256)
+                               (params[:checksum].length == CHECKSUM_LENGTH_SHA1 ||
+                                params[:checksum].length == CHECKSUM_LENGTH_SHA256)
 
     # Camel case (ex) get_meetings to getMeetings to match BBB server
     check_string = action_name.camelcase(:lower)

--- a/test/factories/recording.rb
+++ b/test/factories/recording.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     name
     starttime
     endtime { starttime + 30.minutes }
-    record_id { "#{Digest::SHA1.hexdigest(meeting_id)}-#{starttime.strftime('%s%L')}" }
+    record_id { "#{Digest::SHA256.hexdigest(meeting_id)}-#{starttime.strftime('%s%L')}" }
 
     trait :published do
       published { true }

--- a/test/models/recording_test.rb
+++ b/test/models/recording_test.rb
@@ -20,7 +20,7 @@ class RecordingTest < ActiveSupport::TestCase
     # Not matching
     create(:recording)
 
-    record_id_prefix = Digest::SHA1.hexdigest(meeting_id)
+    record_id_prefix = Digest::SHA256.hexdigest(meeting_id)
 
     rs = Recording.with_recording_id_prefixes([record_id_prefix])
     assert_equal(2, rs.length)
@@ -41,8 +41,8 @@ class RecordingTest < ActiveSupport::TestCase
     # Not matching
     create(:recording)
 
-    record_id_prefix_a = Digest::SHA1.hexdigest(meeting_id_a)
-    record_id_prefix_b = Digest::SHA1.hexdigest(meeting_id_b)
+    record_id_prefix_a = Digest::SHA256.hexdigest(meeting_id_a)
+    record_id_prefix_b = Digest::SHA256.hexdigest(meeting_id_b)
 
     rs = Recording.with_recording_id_prefixes([record_id_prefix_a, record_id_prefix_b])
     assert_equal(4, rs.length)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
 
     def encode_bbb_params(api_method, query_string)
-      checksum = ::Digest::SHA1.hexdigest("#{api_method}#{query_string}#{Rails.configuration.x.loadbalancer_secrets[0]}")
+      checksum = ::Digest::SHA256.hexdigest("#{api_method}#{query_string}#{Rails.configuration.x.loadbalancer_secrets[0]}")
       if query_string.blank?
         "checksum=#{checksum}"
       else


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
BBB supports SHA256 since 2 versions ago, we need to support it and eventually phase out SHA1

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
With api-mate generate requests signed with SHA1 and SHA256, both should work

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
