### PR TITLE
Fix 404 error on recordings playback

### DIFF
--- a/nginx/conf.d/scalelite.common
+++ b/nginx/conf.d/scalelite.common
@@ -1,8 +1,7 @@
 # BigBlueButton recording playback
-location /static-resource {
-  alias /var/bigbluebutton/published;
+location /presentation {
+  root /var/bigbluebutton/published;
   index index.html index.htm;
-  internal;
 }
 
 location /playback/presentation/playback.html {


### PR DESCRIPTION
## Description
Playback load files from /presentation/ directory, so Nginx needs to access this directory from /var/bigbluebutton/published directory.
I changed internal /static-resource location (which is useless, BTW) to /presentation to handle these requests.
as this MR merged #700 will closed.

## Testing Steps
Make a requests to `/api/getRecordings` and opened URL in `playback->format->url`.
Everything is OK now.

## Screenshots (if appropriate):
![Screenshot_2021-10-11_14-46-22](https://user-images.githubusercontent.com/16887332/136781436-1ce5936b-827b-4a96-870e-64606b9649f2.png)

