### PR TITLE
Fix missing argument in servers:yaml command

### DIFF
--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -185,8 +185,8 @@ namespace :servers do
   end
 
   desc 'Return a yaml compatible with servers:sync'
-  task :yaml, [:verbose] => :environment do |_t|
-    puts({ servers: ServerSync.dump(!!args.verbose) }.to_yaml)
+  task :yaml, [:verbose] => :environment do |_t, args|
+    puts({ servers: ServerSync.dump(args.verbose) }.to_yaml)
   end
 
   desc('List all meetings running in specific BigBlueButton servers')


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Closes #727

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

Not too familiar with Ruby. Tested in an existing deployment, and the `servers:yaml` command succeeds with the change:

```bash
$ bundle exec rake servers:yaml[verbose]
(in /srv/scalelite)
---
:servers:
  5c5b1291-f647-4c01-88bd-27b091a27bcc:
    :url: https://$SERVER1/bigbluebutton/api/
    :secret: $REDACTED
    :load_multiplier: !ruby/object:BigDecimal 18:0.1e1
    :enabled:
    :state: enabled
    :load: 0.0
    :online: true
  06f55d8f-9566-4870-8d6e-182713d14cc7:
    :url: https://$SERVER2/bigbluebutton/api/
    :secret: $REDACTED
    :load_multiplier: !ruby/object:BigDecimal 18:0.1e1
    :enabled:
    :state: enabled
    :load: 0.0
    :online: true
```

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
