### PR TITLE
Skip forgery protection on playback resource

### DIFF
--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -13,6 +13,12 @@ class PlaybackController < ApplicationController
     with: :recording_not_found
   )
 
+  # The resource end point is a wrapper over static file serving. The files might include Javascript, which
+  # would be blocked by Rails default CSRF protection - but these are static Javascript files which in
+  # recording playback files are expected not to contain any sensitive user data. (Sensitive data should be
+  # in json or xml files that are protected by browser cross-site request mechanisms.)
+  skip_forgery_protection only: [:resource]
+
   def play
     @playback_format = PlaybackFormat
                        .joins(:recording)


### PR DESCRIPTION
The recording playback files might contain (static) javascript which is
blocked by rails default CSRF protection.

Disable the CSRF protection on this endpoint to fix the issue. This
shouldn't cause any significant safety issues, since xml and json files
with recording data are still protected by browser XSR handling.

Fixes #732