### PR TITLE
GIT-732: Add some tests for protected recording playback

### DIFF
--- a/test/controllers/playback_controller_test.rb
+++ b/test/controllers/playback_controller_test.rb
@@ -8,4 +8,32 @@ class PlaybackControllerTest < ActionDispatch::IntegrationTest
     get "/playback/presentation/2.0/#{recording.record_id}"
     assert_response :success
   end
+
+  test 'playback resource can serve js files' do
+    recording = create(:recording, :published, state: 'published')
+    playback_format = create(
+      :playback_format,
+      recording: recording,
+      format: 'capture',
+      url: "/capture/#{recording.record_id}/"
+    )
+
+    get "#{playback_format.url}capture.js"
+    assert_response(:success)
+    assert_equal("/static-resource#{playback_format.url}capture.js", @response.get_header('X-Accel-Redirect'))
+  end
+
+  test 'protected recording without cookies blocks resource access' do
+    recording = create(:recording, :published, state: 'published', protected: true)
+    playback_format = create(
+      :playback_format,
+      recording: recording,
+      format: 'presentation',
+      url: "/playback/presentation/index.html?meetingID=#{recording.record_id}"
+    )
+
+    get "/#{playback_format.format}/#{recording.record_id}/slides.svg"
+    assert_response(:not_found)
+    assert_not(@response.has_header?('X-Accel-Redirect'))
+  end
 end


### PR DESCRIPTION
This is far from a complete set of tests, but it covers #732 and also
asserts that resources from protected recordings are blocked when the
cookie is missing.
