### PR TITLE
GIT-735: protected recordings can now be disabled (closes #735)

### DIFF
--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -43,7 +43,7 @@ class PlaybackController < ApplicationController
                        .find_by!(format: params[:playback_format], recordings: { record_id: params[:record_id] })
     @recording = @playback_format.recording
 
-    verify_cookie if @recording.protected
+    verify_cookie if Rails.configuration.x.protected_recordings_enabled && @recording.protected
 
     deliver_resource
   end

--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -10,7 +10,7 @@ xml.response do
         xml.internalMeetingID recording.record_id
         xml.name recording.name
         xml.published recording.published ? 'true' : 'false'
-        xml.protected recording.protected
+        xml.protected recording.protected if Rails.configuration.x.protected_recordings_enabled
         xml.state recording.state unless recording.state.nil?
         xml.startTime((recording.starttime.to_r * 1000).to_i)
         xml.endTime((recording.endtime.to_r * 1000).to_i)

--- a/test/controllers/playback_controller_test.rb
+++ b/test/controllers/playback_controller_test.rb
@@ -23,7 +23,7 @@ class PlaybackControllerTest < ActionDispatch::IntegrationTest
     assert_equal("/static-resource#{playback_format.url}capture.js", @response.get_header('X-Accel-Redirect'))
   end
 
-  test 'protected recording without cookies blocks resource access' do
+  test 'protected recording without cookies blocks resource access if enabled' do
     recording = create(:recording, :published, state: 'published', protected: true)
     playback_format = create(
       :playback_format,
@@ -32,6 +32,9 @@ class PlaybackControllerTest < ActionDispatch::IntegrationTest
       url: "/playback/presentation/index.html?meetingID=#{recording.record_id}"
     )
 
+    get "/#{playback_format.format}/#{recording.record_id}/slides.svg"
+    assert_response(:success)
+    Rails.configuration.x.protected_recordings_enabled = true
     get "/#{playback_format.format}/#{recording.record_id}/slides.svg"
     assert_response(:not_found)
     assert_not(@response.has_header?('X-Accel-Redirect'))


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The ability of disabling protected recordings was never implemented. This is a serious bug that affects backward compatibility.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Set PROTECTED_RECORDINGS_ENABLED=true
2. Start SL, and create a recording
3. after the recording is imported, verify that protected recording works by accessing the playback, copy the URL and paste it on a different browser. The response should be a 404
4. Set PROTECTED_RECORDINGS_ENABLED=false
5. Restart SL
6. verify that protected recording is now disabled by accessing the playback, copy the URL and paste it on a different browser. The response should now be the recording as in the main browser

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
