### PR TITLE
Fix nginx startup

### DIFF
--- a/nginx/start
+++ b/nginx/start
@@ -25,11 +25,10 @@ else
 	nginx_template=/etc/nginx/conf.d/scalelite.template
 fi
 
-# apply SCALELITE_API port from environment variable or use default port 3000
-$SCALELITE_API_PORT=${SCALELITE_API_PORT:-3000}
-envsubst '$SCALELITE_API_PORT' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
+SCALELITE_API_PORT=${SCALELITE_API_PORT:-3000}
 
-envsubst '$URL_HOST' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
+envsubst '$URL_HOST $SCALELITE_API_PORT' < $nginx_template >/etc/nginx/conf.d/scalelite.conf
+
 unset nginx_template
 
 mkdir -p /run/nginx


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
#724 introduced an issue where nginx would fail to start with the following error:

```sh
Generating templated nginx configuration...
Using non-SSL configuration template.
Starting nginx periodic reload process...
Starting nginx...
nginx: [emerg] 91#91: unknown "scalelite_api_port" variable
nginx: [emerg] unknown "scalelite_api_port" variable
```

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Try to start the container for `blindsidenetwks/scalelite:v1.3.1-beta.2-nginx`.
