### PR TITLE
GIT-743: Fix setting SCALELITE_API_PORT env var in nginx config

### DIFF
--- a/nginx/start
+++ b/nginx/start
@@ -26,10 +26,10 @@ else
 fi
 
 # apply SCALELITE_API port from environment variable or use default port 3000
-$SCALELITE_API_PORT=${SCALELITE_API_PORT:-3000}
-envsubst '$SCALELITE_API_PORT' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
+SCALELITE_API_PORT=${SCALELITE_API_PORT:-3000}
+export SCALELITE_API_PORT
 
-envsubst '$URL_HOST' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
+envsubst '$SCALELITE_API_PORT $URL_HOST' <$nginx_template >/etc/nginx/conf.d/scalelite.conf
 unset nginx_template
 
 mkdir -p /run/nginx


### PR DESCRIPTION
The assignment to the variable was incorrectly prefixed with $, so it
wasn't getting set correctly; and besides that the variable wasn't
exported to the environment so the 'envsubst' tool wouldn't pick it up.

Note that since the shell used is /bin/sh (which can be 'dash' in some
distros), the more compatible form of using export separately from
setting the variable is used here.

The way the envsubst tool was being run was incorrect; the second time
it was run it would replace the file without setting the api port at
all. Fix that by substituting both variables in a single call to
envsubst.

Fixes #743