### PR TITLE
Fixed servers:sync default args

### DIFF
--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -177,6 +177,7 @@ namespace :servers do
   desc 'Sync cluster state with servers defined in a YAML file'
   task :sync, [:path, :mode, :dryrun] => :environment do |_t, args|
     raise "Missing 'path' parameter" if args.path.blank?
+    args.with_defaults(mode: 'cordon', dryrun: false)
 
     ServerSync.sync_file(args.path, args.mode, args.dryrun)
   rescue StandardError => e


### PR DESCRIPTION
fixes #738 

If an argument is not passed into a rake task, it automatically defaults the value to `''` which means the optional parameters in the `sync_file` method are never used