### PR TITLE
Enforce checksum algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `PROTECTED_RECORDINGS_TIMEOUT`: Protected recordings resource access cookie timeout in minutes. This is the amount of time that a user will be granted access to view a recording for after clicking on the one-time-use link. Defaults to 360 minutes (6 hours).
 * `SCALELITE_API_PORT`: Runs the SCALELITE_API in custom port number. Defaults to 3000.
 * `DEFAULT_LOCALE`: Change the language that user facing pages displays in (currently supports `en`)
+* `ENFORCE_CHECKSUM_ALGORITHM`: Force the use of one algorithm when verifying or generating checksums. When not set, Scalelite accepts checksums generated with SHA1, SHA256, or SHA512 and calls to BigBlueButton servers use SHA256.
 
 ### Customizing Strings
 

--- a/app/classes/checksum.rb
+++ b/app/classes/checksum.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Checksum
+  CHECKSUM_LENGTH_SHA1 = 40
+  CHECKSUM_LENGTH_SHA256 = 64
+  CHECKSUM_LENGTH_SHA512 = 128
+
+  private :initialize
+
+  def initialize
+  end
+
+  def self.get_algorithm(checksum = nil)
+    case ENV['ENFORCE_CHECKSUM_ALGORITHM']
+    when nil
+      return ChecksumSha256.new if checksum.nil?
+      case checksum.size
+      when CHECKSUM_LENGTH_SHA1
+          ChecksumSha1.new
+      when CHECKSUM_LENGTH_SHA256
+          ChecksumSha256.new
+      when CHECKSUM_LENGTH_SHA512
+          ChecksumSha512.new
+      else
+          raise ChecksumError
+      end
+    when 'SHA1'
+      ChecksumSha1.new
+    when 'SHA256'
+      ChecksumSha256.new
+    when 'SHA512'
+      ChecksumSha512.new
+    else
+      raise ChecksumError
+    end
+  end
+
+  def self.verify(data, checksum)
+    get_algorithm(checksum).verify(data, checksum)
+  end
+
+  def self.generate(data)
+    get_algorithm.generate(data)
+  end
+end

--- a/app/classes/checksum.rb
+++ b/app/classes/checksum.rb
@@ -13,7 +13,9 @@ class Checksum
   def self.get_algorithm(checksum = nil)
     case ENV['ENFORCE_CHECKSUM_ALGORITHM']
     when nil
+      # Default algorithm
       return ChecksumSha256.new if checksum.nil?
+      
       case checksum.size
       when CHECKSUM_LENGTH_SHA1
           ChecksumSha1.new

--- a/app/classes/checksum.rb
+++ b/app/classes/checksum.rb
@@ -15,7 +15,7 @@ class Checksum
     when nil
       # Default algorithm
       return ChecksumSha256.new if checksum.nil?
-      
+
       case checksum.size
       when CHECKSUM_LENGTH_SHA1
           ChecksumSha1.new

--- a/app/classes/checksum_sha1.rb
+++ b/app/classes/checksum_sha1.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'active_support'
+require 'bbb_errors'
+
+class ChecksumSha1
+  include BBBErrors
+
+  def generate(data)
+    Digest::SHA1.hexdigest data
+  end
+
+  def verify(data, checksum)
+    return true if Rails.configuration.x.loadbalancer_secrets.any? do |secret|
+      generated_checksum = generate(data + secret)
+      ActiveSupport::SecurityUtils.secure_compare(generated_checksum, checksum)
+    end
+    raise ChecksumError
+  end
+end

--- a/app/classes/checksum_sha256.rb
+++ b/app/classes/checksum_sha256.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChecksumSha256 < ChecksumSha1
+  def generate(data)
+    Digest::SHA256.hexdigest data
+  end
+end

--- a/app/classes/checksum_sha512.rb
+++ b/app/classes/checksum_sha512.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChecksumSha512 < ChecksumSha1
+  def generate(data)
+    Digest::SHA512.hexdigest data
+  end
+end


### PR DESCRIPTION
## Description

- refactored the selection, validation, and generating of checksums
- add support for SHA512 checksums
- add support to force the use of a specific algorithm
- updated README

## Testing Steps

1. Validated the generation of checksums using irb and php to ensure all checksums matched.
2. Used API MATE to generate urls to connect to my development environment (http://localhost:3000/...)
3. Used irb to generate urls with SHA512 checksums
4. Added ENFORCE_CHECKSUM_ALGORITHM environmental variable and retested create, join, getMeetings, getMeetingInfo actions
5. Added test cases for SHA512 checksum
6. Added test cases mock the setting of ENFORCE_CHECKSUM_ALGORITHM 
7. Generated Amazon Linux-based images and tested with Scalelite Enterprise

## Screenshots (if appropriate):

No applicable screenshots.