### PR TITLE
SL-243 updates to alpine base docker image after last security patch 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,11 @@ FROM alpine AS nginx
 RUN apk add --no-cache nginx tini gettext \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
-RUN rm /etc/nginx/conf.d/default.conf
+RUN rm /etc/nginx/http.d/default.conf
 COPY --from=bbb-playback /etc/bigbluebutton/nginx /etc/bigbluebutton/nginx/
 COPY --from=bbb-playback /var/bigbluebutton/playback /var/bigbluebutton/playback/
 COPY nginx/start /etc/nginx/start
 COPY nginx/dhparam.pem /etc/nginx/dhparam.pem
-COPY nginx/conf.d /etc/nginx/http.d/
 # This will be needed with alpine 3.14 since conf.d is being phased out.
 # RUN ln -s /etc/nginx/http.d/ /etc/nginx/conf.d
 EXPOSE 80
@@ -39,19 +38,33 @@ CMD [ "/etc/nginx/start", "-g", "daemon off;" ]
 
 FROM alpine AS base
 RUN apk add --no-cache \
-    libpq
-RUN apk add --no-cache \
     libpq \
     libxml2 \
     libxslt \
-    ruby \
-    ruby-irb \
-    ruby-bigdecimal \
-    ruby-bundler \
-    ruby-json \
     tini \
     tzdata \
     shared-mime-info
+# ruby-start.
+# Install Ruby from sources since Scalelite does not use the version shipped with Apline.
+ARG RUBY_RELEASE="https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.gz"
+ARG RUBY="ruby-2.7.6"
+RUN apk add --no-cache git make gcc g++ libc-dev pkgconfig \
+    libxml2-dev libxslt-dev postgresql-dev coreutils curl wget bash \
+    gnupg tar linux-headers bison readline-dev readline zlib-dev \
+    zlib yaml-dev autoconf ncurses-dev curl-dev apache2-dev \
+    libx11-dev libffi-dev tcl-dev tk-dev
+RUN wget --no-verbose -O ruby.tar.gz ${RUBY_RELEASE} && \
+    tar -xf ruby.tar.gz && \
+    cd /${RUBY} && \
+    ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+    ./configure --disable-install-doc && \
+    make && \
+    make test && \
+    make install
+RUN cd / && \
+    rm ruby.tar.gz && \
+    rm -rf ${RUBY_NAME}
+# ruby-end.
 RUN addgroup scalelite --gid 1000 && \
     adduser -u 1000 -h /srv/scalelite -G scalelite -D scalelite
 RUN addgroup scalelite-spool --gid 2000 && \

--- a/dockerfiles/v1/bionic240-alpine
+++ b/dockerfiles/v1/bionic240-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.13 AS alpine
+FROM alpine:3.15 AS alpine
 
 FROM ubuntu:18.04 AS bbb-playback
 ENV DEBIAN_FRONTEND=noninteractive
@@ -24,12 +24,11 @@ FROM alpine AS nginx
 RUN apk add --no-cache nginx tini gettext \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
-RUN rm /etc/nginx/conf.d/default.conf
+RUN rm /etc/nginx/http.d/default.conf
 COPY --from=bbb-playback /etc/bigbluebutton/nginx /etc/bigbluebutton/nginx/
 COPY --from=bbb-playback /var/bigbluebutton/playback /var/bigbluebutton/playback/
 COPY nginx/start /etc/nginx/start
 COPY nginx/dhparam.pem /etc/nginx/dhparam.pem
-COPY nginx/conf.d /etc/nginx/http.d/
 # This will be needed with alpine 3.14 since conf.d is being phased out.
 # RUN ln -s /etc/nginx/http.d/ /etc/nginx/conf.d
 EXPOSE 80
@@ -39,19 +38,33 @@ CMD [ "/etc/nginx/start", "-g", "daemon off;" ]
 
 FROM alpine AS base
 RUN apk add --no-cache \
-    libpq
-RUN apk add --no-cache \
     libpq \
     libxml2 \
     libxslt \
-    ruby \
-    ruby-irb \
-    ruby-bigdecimal \
-    ruby-bundler \
-    ruby-json \
     tini \
     tzdata \
     shared-mime-info
+# ruby-start.
+# Install Ruby from sources since Scalelite does not use the version shipped with Apline.
+ARG RUBY_RELEASE="https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.gz"
+ARG RUBY="ruby-2.7.6"
+RUN apk add --no-cache git make gcc g++ libc-dev pkgconfig \
+    libxml2-dev libxslt-dev postgresql-dev coreutils curl wget bash \
+    gnupg tar linux-headers bison readline-dev readline zlib-dev \
+    zlib yaml-dev autoconf ncurses-dev curl-dev apache2-dev \
+    libx11-dev libffi-dev tcl-dev tk-dev
+RUN wget --no-verbose -O ruby.tar.gz ${RUBY_RELEASE} && \
+    tar -xf ruby.tar.gz && \
+    cd /${RUBY} && \
+    ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+    ./configure --disable-install-doc && \
+    make && \
+    make test && \
+    make install
+RUN cd / && \
+    rm ruby.tar.gz && \
+    rm -rf ${RUBY_NAME}
+# ruby-end.
 RUN addgroup scalelite --gid 1000 && \
     adduser -u 1000 -h /srv/scalelite -G scalelite -D scalelite
 RUN addgroup scalelite-spool --gid 2000 && \


### PR DESCRIPTION
After last security Snyk patch was applied the build of alpine docker images was broken. This is because alpine 15 comes with ruby 3 and some dependencies are still tied to 2.7.

While the version of ruby must be updated, as a work around we install 2.7.6 from sources.


