### PR TITLE
Fix #845 Nginx - Connection refused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ COPY --from=bbb-playback /etc/bigbluebutton/nginx /etc/bigbluebutton/nginx/
 COPY --from=bbb-playback /var/bigbluebutton/playback /var/bigbluebutton/playback/
 COPY nginx/start /etc/nginx/start
 COPY nginx/dhparam.pem /etc/nginx/dhparam.pem
-# This will be needed with alpine 3.14 since conf.d is being phased out.
-# RUN ln -s /etc/nginx/http.d/ /etc/nginx/conf.d
+COPY nginx/conf.d /etc/nginx/http.d/
 EXPOSE 80
 EXPOSE 443
 ENV NGINX_HOSTNAME=localhost


### PR DESCRIPTION
Copy `nginx/conf.d` to docker image. The corresponding line was removed in f71012d1 prior to 1.3.5 breaking docker deployments. See #845
