### PR TITLE
SL-273: Change Redis#sadd to sadd?

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -101,7 +101,7 @@ class Meeting < ApplicationRedisRecord
       meeting_key = key
       redis.multi do |transaction|
         transaction.hset(meeting_key, 'server_id', server_id) if server_id_changed?
-        transaction.sadd('meetings', id) if id_changed?
+        transaction.sadd?('meetings', id) if id_changed?
       end
     end
 
@@ -161,7 +161,7 @@ class Meeting < ApplicationRedisRecord
           transaction.hsetnx(meeting_key, 'moderator_pw', moderator_pw)
           transaction.hsetnx(meeting_key, 'voice_bridge', voice_bridge)
           transaction.hgetall(meeting_key)
-          transaction.sadd('meetings', id)
+          transaction.sadd?('meetings', id)
           transaction.hsetnx(meeting_key, 'tenant_id', tenant_id)
         end
 

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -98,7 +98,7 @@ class Server < ApplicationRedisRecord
           pipeline.hset(server_key, 'users', users) if users_changed?
           pipeline.hset(server_key, 'largest_meeting', largest_meeting) if largest_meeting_changed?
           pipeline.hset(server_key, 'videos', videos) if videos_changed?
-          pipeline.sadd('servers', id) if id_changed?
+          pipeline.sadd?('servers', id) if id_changed?
           state.present? ? save_with_state(pipeline) : save_without_state(pipeline)
         end
 
@@ -116,7 +116,7 @@ class Server < ApplicationRedisRecord
 
   def handle_enabled_state(redis)
     if state_changed?
-      redis.sadd('server_enabled', id)
+      redis.sadd?('server_enabled', id)
       redis.zadd('server_load', self.load, id) if self.load.present?
       redis.zrem('cordoned_server_load', id)
     end
@@ -155,7 +155,7 @@ class Server < ApplicationRedisRecord
   def save_without_state(redis)
     if enabled_changed?
       if enabled
-        redis.sadd('server_enabled', id)
+        redis.sadd?('server_enabled', id)
       else
         redis.srem('server_enabled', id)
         redis.zrem('server_load', id)

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Meeting, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
           redis.mapped_hmset('meeting:test-meeting-2', server_id: 'test-server-2')
-          redis.sadd('meetings', %w[test-meeting-1 test-meeting-2])
+          redis.sadd?('meetings', %w[test-meeting-1 test-meeting-2])
         end
       end
 
@@ -142,9 +142,9 @@ RSpec.describe Meeting, redis: true do
           # server
           redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
 
-          redis.sadd('meetings', %w[test-meeting-01 test-meeting-02
-                                    test-meeting-11 test-meeting-12 test-meeting-13
-                                    test-meeting-21 test-meeting-22])
+          redis.sadd?('meetings', %w[test-meeting-01 test-meeting-02
+                                     test-meeting-11 test-meeting-12 test-meeting-13
+                                     test-meeting-21 test-meeting-22])
         end
       end
 
@@ -184,7 +184,7 @@ RSpec.describe Meeting, redis: true do
     before do
       RedisStore.with_connection do |redis|
         redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-        redis.sadd('servers', 'test-server-1')
+        redis.sadd?('servers', 'test-server-1')
       end
     end
 
@@ -206,11 +206,11 @@ RSpec.describe Meeting, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-          redis.sadd('servers', 'test-server-1')
+          redis.sadd?('servers', 'test-server-1')
           redis.mapped_hmset('server:test-server-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2')
-          redis.sadd('servers', 'test-server-2')
+          redis.sadd?('servers', 'test-server-2')
           redis.mapped_hmset('meeting:Demo Meeting', server_id: 'test-server-1')
-          redis.sadd('meetings', 'Demo Meeting')
+          redis.sadd?('meetings', 'Demo Meeting')
         end
       end
 
@@ -241,11 +241,11 @@ RSpec.describe Meeting, redis: true do
     before do
       RedisStore.with_connection do |redis|
         redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-        redis.sadd('servers', 'test-server-1')
+        redis.sadd?('servers', 'test-server-1')
         redis.mapped_hmset('server:test-server-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2')
-        redis.sadd('servers', 'test-server-2')
+        redis.sadd?('servers', 'test-server-2')
         redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
-        redis.sadd('meetings', 'test-meeting-1')
+        redis.sadd?('meetings', 'test-meeting-1')
       end
     end
 
@@ -280,9 +280,9 @@ RSpec.describe Meeting, redis: true do
     before do
       RedisStore.with_connection do |redis|
         redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-        redis.sadd('servers', 'test-server-1')
+        redis.sadd?('servers', 'test-server-1')
         redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
-        redis.sadd('meetings', 'test-meeting-1')
+        redis.sadd?('meetings', 'test-meeting-1')
       end
     end
 
@@ -316,7 +316,7 @@ RSpec.describe Meeting, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-          redis.sadd('servers', 'test-server-1')
+          redis.sadd?('servers', 'test-server-1')
         end
 
         meeting.server = server

--- a/spec/models/server_spec.rb
+++ b/spec/models/server_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
+          redis.sadd?('servers', 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-          redis.sadd('servers', 'test-2')
+          redis.sadd?('servers', 'test-2')
         end
       end
 
@@ -38,13 +38,13 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              online: 'true')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 2, 'test-2')
         end
       end
@@ -67,13 +67,13 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              state: 'enabled')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              online: 'true', state: 'enabled')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 2, 'test-2')
         end
       end
@@ -96,11 +96,11 @@ RSpec.describe Server, redis: true do
         before do
           RedisStore.with_connection do |redis|
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-            redis.sadd('servers', 'test-1')
-            redis.sadd('server_enabled', 'test-1')
+            redis.sadd?('servers', 'test-1')
+            redis.sadd?('server_enabled', 'test-1')
             redis.zadd('server_load', 1, 'test-1')
             redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-            redis.sadd('servers', 'test-2')
+            redis.sadd?('servers', 'test-2')
           end
         end
 
@@ -121,12 +121,12 @@ RSpec.describe Server, redis: true do
           RedisStore.with_connection do |redis|
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                state: 'enabled')
-            redis.sadd('servers', 'test-1')
-            redis.sadd('server_enabled', 'test-1')
+            redis.sadd?('servers', 'test-1')
+            redis.sadd?('server_enabled', 'test-1')
             redis.zadd('server_load', 1, 'test-1')
             redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                state: 'disabled')
-            redis.sadd('servers', 'test-2')
+            redis.sadd?('servers', 'test-2')
           end
         end
 
@@ -176,13 +176,13 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              enabled: 'true')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              enabled: 'false')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 2, 'test-2')
         end
       end
@@ -202,13 +202,13 @@ RSpec.describe Server, redis: true do
             redis.flushall
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                state: 'enabled')
-            redis.sadd('servers', 'test-1')
-            redis.sadd('server_enabled', 'test-1')
+            redis.sadd?('servers', 'test-1')
+            redis.sadd?('server_enabled', 'test-1')
             redis.zadd('server_load', 1, 'test-1')
             redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                state: 'cordoned')
-            redis.sadd('servers', 'test-2')
-            redis.sadd('server_enabled', 'test-2')
+            redis.sadd?('servers', 'test-2')
+            redis.sadd?('server_enabled', 'test-2')
             redis.zadd('server_load', 2, 'test-2')
           end
         end
@@ -228,13 +228,13 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              state: 'enabled')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              state: 'enabled')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 1, 'test-2')
         end
 
@@ -256,13 +256,13 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              enabled: 'false')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              enabled: 'false')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 1, 'test-1')
         end
 
@@ -286,13 +286,13 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              state: 'enabled')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 5, 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              state: 'enabled')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 5, 'test-2')
         end
 
@@ -315,13 +315,13 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              enabled: 'true')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 5, 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              enabled: 'true')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 5, 'test-2')
         end
 
@@ -347,11 +347,11 @@ RSpec.describe Server, redis: true do
       RedisStore.with_connection do |redis|
         redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                            state: 'enabled')
-        redis.sadd('servers', 'test-1')
+        redis.sadd?('servers', 'test-1')
         redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                            state: 'cordoned')
-        redis.sadd('servers', 'test-2')
-        redis.sadd('server_enabled', 'test-2')
+        redis.sadd?('servers', 'test-2')
+        redis.sadd?('server_enabled', 'test-2')
         redis.zadd('cordoned_server_load', 2, 'test-2')
         redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
                            enabled: true)
@@ -397,16 +397,16 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              state: 'cordoned')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 2, 'test-2')
           redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
                              state: 'cordoned')
-          redis.sadd('servers', 'test-3')
+          redis.sadd?('servers', 'test-3')
         end
       end
 
@@ -431,16 +431,16 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              enabled: 'false')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                              enabled: 'true')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 2, 'test-2')
           redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
                              enabled: 'false')
-          redis.sadd('servers', 'test-3')
+          redis.sadd?('servers', 'test-3')
         end
       end
 
@@ -466,8 +466,8 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
         end
         server.increment_load(2)
       end
@@ -490,8 +490,8 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-          redis.sadd('servers', 'test-2')
-          redis.sadd('server_enabled', 'test-2')
+          redis.sadd?('servers', 'test-2')
+          redis.sadd?('server_enabled', 'test-2')
           redis.zadd('server_load', 2, 'test-2')
         end
         server.increment_load(2)
@@ -638,7 +638,7 @@ RSpec.describe Server, redis: true do
     before do
       RedisStore.with_connection do |redis|
         redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-        redis.sadd('servers', 'test-1')
+        redis.sadd?('servers', 'test-1')
       end
     end
 
@@ -694,8 +694,8 @@ RSpec.describe Server, redis: true do
           RedisStore.with_connection do |redis|
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                state: 'enabled')
-            redis.sadd('servers', 'test-1')
-            redis.sadd('server_enabled', 'test-1')
+            redis.sadd?('servers', 'test-1')
+            redis.sadd?('server_enabled', 'test-1')
           end
 
           server.load = 1
@@ -715,8 +715,8 @@ RSpec.describe Server, redis: true do
           RedisStore.with_connection do |redis|
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                state: 'enabled')
-            redis.sadd('servers', 'test-1')
-            redis.sadd('server_enabled', 'test-1')
+            redis.sadd?('servers', 'test-1')
+            redis.sadd?('server_enabled', 'test-1')
             redis.zadd('server_load', 1, 'test-1')
           end
 
@@ -737,8 +737,8 @@ RSpec.describe Server, redis: true do
           RedisStore.with_connection do |redis|
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                state: 'enabled')
-            redis.sadd('servers', 'test-1')
-            redis.sadd('server_enabled', 'test-1')
+            redis.sadd?('servers', 'test-1')
+            redis.sadd?('server_enabled', 'test-1')
             redis.zadd('server_load', 1, 'test-1')
           end
 
@@ -759,7 +759,7 @@ RSpec.describe Server, redis: true do
           RedisStore.with_connection do |redis|
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                state: 'disabled')
-            redis.sadd('servers', 'test-1')
+            redis.sadd?('servers', 'test-1')
 
             server.load = 2
             server.save!
@@ -780,7 +780,7 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              online: 'false', state: 'enabled')
-          redis.sadd('servers', 'test-1')
+          redis.sadd?('servers', 'test-1')
         end
       end
 
@@ -802,8 +802,8 @@ RSpec.describe Server, redis: true do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                              state: 'enabled')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
 
           server.state = 'disabled'
@@ -832,7 +832,7 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
+          redis.sadd?('servers', 'test-1')
         end
 
         server.state = 'enabled'
@@ -869,8 +869,8 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
         end
 
@@ -891,8 +891,8 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
-          redis.sadd('server_enabled', 'test-1')
+          redis.sadd?('servers', 'test-1')
+          redis.sadd?('server_enabled', 'test-1')
         end
 
         server.destroy!
@@ -912,7 +912,7 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
+          redis.sadd?('servers', 'test-1')
         end
 
         server.destroy!
@@ -932,7 +932,7 @@ RSpec.describe Server, redis: true do
       before do
         RedisStore.with_connection do |redis|
           redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-          redis.sadd('servers', 'test-1')
+          redis.sadd?('servers', 'test-1')
           redis.zadd('server_load', 1, 'test-1')
         end
 

--- a/test/models/meeting_test.rb
+++ b/test/models/meeting_test.rb
@@ -48,7 +48,7 @@ class MeetingTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
       redis.mapped_hmset('meeting:test-meeting-2', server_id: 'test-server-2')
-      redis.sadd('meetings', %w[test-meeting-1 test-meeting-2])
+      redis.sadd?('meetings', %w[test-meeting-1 test-meeting-2])
     end
 
     all_meetings = Meeting.all
@@ -59,7 +59,7 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting create' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
     end
 
     server = Server.find('test-server-1')
@@ -79,7 +79,7 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting atomic create (new meeting)' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
     end
 
     server = Server.find('test-server-1')
@@ -102,11 +102,11 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting atomic create (existing meeting)' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
       redis.mapped_hmset('server:test-server-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2')
-      redis.sadd('servers', 'test-server-2')
+      redis.sadd?('servers', 'test-server-2')
       redis.mapped_hmset('meeting:Demo Meeting', server_id: 'test-server-1', voice_bridge: '12435687')
-      redis.sadd('meetings', 'Demo Meeting')
+      redis.sadd?('meetings', 'Demo Meeting')
       redis.hset('voice_bridges', '12435687', 'Demo Meeting')
     end
 
@@ -131,9 +131,9 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting update id' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
       redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
-      redis.sadd('meetings', 'test-meeting-1')
+      redis.sadd?('meetings', 'test-meeting-1')
     end
 
     meeting = Meeting.find('test-meeting-1')
@@ -146,11 +146,11 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting update server_id' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
       redis.mapped_hmset('server:test-server-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2')
-      redis.sadd('servers', 'test-server-2')
+      redis.sadd?('servers', 'test-server-2')
       redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
-      redis.sadd('meetings', 'test-meeting-1')
+      redis.sadd?('meetings', 'test-meeting-1')
     end
 
     meeting = Meeting.find('test-meeting-1')
@@ -167,11 +167,11 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting update server' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
       redis.mapped_hmset('server:test-server-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2')
-      redis.sadd('servers', 'test-server-2')
+      redis.sadd?('servers', 'test-server-2')
       redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
-      redis.sadd('meetings', 'test-meeting-1')
+      redis.sadd?('meetings', 'test-meeting-1')
     end
 
     meeting = Meeting.find('test-meeting-1')
@@ -188,9 +188,9 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting destroy' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
       redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
-      redis.sadd('meetings', 'test-meeting-1')
+      redis.sadd?('meetings', 'test-meeting-1')
     end
 
     meeting = Meeting.find('test-meeting-1')
@@ -205,9 +205,9 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting destroy with pending changes' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
       redis.mapped_hmset('meeting:test-meeting-1', server_id: 'test-server-1')
-      redis.sadd('meetings', 'test-meeting-1')
+      redis.sadd?('meetings', 'test-meeting-1')
     end
 
     meeting = Meeting.find('test-meeting-1')
@@ -221,7 +221,7 @@ class MeetingTest < ActiveSupport::TestCase
   test 'Meeting destroy with non-persisted object' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
     end
 
     meeting = Meeting.new
@@ -284,7 +284,7 @@ class MeetingTest < ActiveSupport::TestCase
   test 'cannot update voice_bridge' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-server-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1')
-      redis.sadd('servers', 'test-server-1')
+      redis.sadd?('servers', 'test-server-1')
     end
     server = Server.find('test-server-1')
     meeting = Meeting.find_or_create_with_server('Demo Meeting', server, 'mp')

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -18,9 +18,9 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server find with no load' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-      redis.sadd('servers', 'test-2')
+      redis.sadd?('servers', 'test-2')
     end
 
     server = Server.find('test-1')
@@ -36,13 +36,13 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server find with load' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           online: 'true')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 2, 'test-2')
     end
 
@@ -61,13 +61,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           online: 'true', state: 'enabled')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 2, 'test-2')
     end
 
@@ -85,11 +85,11 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server find disabled' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-      redis.sadd('servers', 'test-2')
+      redis.sadd?('servers', 'test-2')
     end
 
     server = Server.find('test-2')
@@ -106,12 +106,12 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           state: 'disabled')
-      redis.sadd('servers', 'test-2')
+      redis.sadd?('servers', 'test-2')
     end
 
     server = Server.find('test-2')
@@ -147,13 +147,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           enabled: 'true')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           enabled: 'false')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 2, 'test-2')
     end
 
@@ -170,13 +170,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           state: 'cordoned')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 2, 'test-2')
     end
 
@@ -193,13 +193,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 1, 'test-2')
     end
 
@@ -217,13 +217,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           enabled: 'false')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           enabled: 'false')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 1, 'test-1')
     end
 
@@ -241,13 +241,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 5, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 5, 'test-2')
     end
 
@@ -266,13 +266,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 5, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 5, 'test-2')
     end
 
@@ -291,13 +291,13 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           enabled: 'true')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 5, 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           enabled: 'true')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 5, 'test-2')
     end
 
@@ -320,11 +320,11 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           state: 'cordoned')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('cordoned_server_load', 2, 'test-2')
       redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
                                           enabled: true)
@@ -360,16 +360,16 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server available returns available servers with state as enabled' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           state: 'cordoned')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 2, 'test-2')
       redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
                                           state: 'cordoned')
-      redis.sadd('servers', 'test-3')
+      redis.sadd?('servers', 'test-3')
     end
 
     servers = Server.available
@@ -387,16 +387,16 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           enabled: 'false')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
                                           enabled: 'true')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 2, 'test-2')
       redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
                                           enabled: 'false')
-      redis.sadd('servers', 'test-3')
+      redis.sadd?('servers', 'test-3')
     end
 
     servers = Server.available
@@ -412,8 +412,8 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server increment load' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
       redis.zadd('server_load', 2, 'test-2')
     end
 
@@ -430,8 +430,8 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server increment load not available' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret')
-      redis.sadd('servers', 'test-2')
-      redis.sadd('server_enabled', 'test-2')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
     end
 
     server = Server.find('test-2')
@@ -527,7 +527,7 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server update id' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -540,7 +540,7 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server update url' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -557,7 +557,7 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server update secret' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -575,8 +575,8 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -593,8 +593,8 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
     end
 
@@ -612,8 +612,8 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
     end
 
@@ -631,7 +631,7 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'disabled')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -648,7 +648,7 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           online: 'false', state: 'enabled')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -666,8 +666,8 @@ class ServerTest < ActiveSupport::TestCase
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           state: 'enabled')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
     end
 
@@ -686,7 +686,7 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server enable' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -703,8 +703,8 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server destroy active' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
     end
 
@@ -722,8 +722,8 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server destroy unavailable' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
-      redis.sadd('server_enabled', 'test-1')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -740,7 +740,7 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server destroy disabled' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
     end
 
     server = Server.find('test-1')
@@ -757,7 +757,7 @@ class ServerTest < ActiveSupport::TestCase
   test 'Server destroy with pending changes' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret')
-      redis.sadd('servers', 'test-1')
+      redis.sadd?('servers', 'test-1')
       redis.zadd('server_load', 1, 'test-1')
     end
 


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Update sadd to sadd? to get rid of the following warning: `Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead.`

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
