### PR TITLE
SL-273: Replace depreciated Redis.current method

### DIFF
--- a/spec/redis_helper.rb
+++ b/spec/redis_helper.rb
@@ -5,15 +5,17 @@ module RSpec
     # When this module is included into the rspec config,
     # it will set up an around(:each) block to clear redis.
     def self.included(rspec)
-      rspec.after(:each, redis: true) do |_example|
-        Redis.current.flushdb
+      rspec.around(:each, redis: true) do |example|
+        with_clean_redis do
+          example.run
+        end
       end
     end
 
     CONFIG = { url: ENV["REDIS_URL"] || "redis://127.0.0.1:6379/1" }
 
     def redis
-      @redis ||= ::Redis.connect(CONFIG)
+      @redis ||= ::Redis.new(CONFIG)
     end
 
     def with_clean_redis


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes the following warning:
Redis.current is deprecated and will be removed in 5.0. (called from: /home/ubuntu/scalelite/spec/redis_helper.rb:9:in `block in included'). 

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
