### PR TITLE
Fix Freeswitch tests - unauthenticated requests (0)

### DIFF
--- a/test/controllers/fsapi_controller_test.rb
+++ b/test/controllers/fsapi_controller_test.rb
@@ -206,7 +206,9 @@ class FsapiControllerTest < ActionDispatch::IntegrationTest
 
   def test_pin_prompt_allotted_timeout_not_set
     Rails.configuration.x.stub(:fsapi_max_duration, 0) do
-      post(fsapi_url, params: { section: 'dialplan', 'Caller-Destination-Number': '5551234' })
+      FsapiController.stub_any_instance(:authenticate, true) do
+        post(fsapi_url, params: { section: 'dialplan', 'Caller-Destination-Number': '5551234' })
+      end
     end
     assert_response(:success)
     assert_select('section > context > extension > condition') do
@@ -216,7 +218,9 @@ class FsapiControllerTest < ActionDispatch::IntegrationTest
 
   def test_pin_prompt_allotted_timeout
     Rails.configuration.x.stub(:fsapi_max_duration, 90) do
-      post(fsapi_url, params: { section: 'dialplan', 'Caller-Destination-Number': '5551234' })
+      FsapiController.stub_any_instance(:authenticate, true) do
+        post(fsapi_url, params: { section: 'dialplan', 'Caller-Destination-Number': '5551234' })
+      end
     end
     assert_response(:success)
     Rails.logger.debug { @response.body }


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The last two tests in `freeswitchapi_controller_test` are failing because the requests are unauthenticated.

- Add an authenticated request stub.

Not sure if this is wanted or not, as all other test have authenticated requests.
