### PR TITLE
SL-281: Added support for insertDocument

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   # Handles all unsupported requests (inccuding root)
   def unsupported_request
     raise UnsupportedRequestError

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     match 'end', to: 'bigbluebutton_api#end', via: [:get, :post]
     match 'join', to: 'bigbluebutton_api#join', via: [:get, :post]
     post 'analytics_callback', to: 'bigbluebutton_api#analytics_callback', as: :analytics_callback
+    post 'insertDocument', to: 'bigbluebutton_api#insert_document'
     if Rails.configuration.x.recording_disabled
       match('getRecordings', to: 'bigbluebutton_api#get_recordings_disabled', as: :get_recordings, via: [:get, :post])
       match('publishRecordings', to: 'bigbluebutton_api#recordings_disabled', as: :publish_recordings, via: [:get, :post])

--- a/spec/requests/bigbluebutton_api_controller_spec.rb
+++ b/spec/requests/bigbluebutton_api_controller_spec.rb
@@ -1240,6 +1240,42 @@ RSpec.describe BigBlueButtonApiController, redis: true do
     end
   end
 
+  describe '#insert_document' do
+    it "responds with MissingMeetingIDError if meeting ID is not passed" do
+      post bigbluebutton_api_insertDocument_url
+
+      response_xml = Nokogiri.XML(response.body)
+      expected_error = BBBErrors::MissingMeetingIDError.new
+      expect(response_xml.at_xpath("/response/returncode").text).to(eq("FAILED"))
+      expect(response_xml.at_xpath("/response/messageKey").text).to(eq(expected_error.message_key))
+      expect(response_xml.at_xpath("/response/message").text).to(eq(expected_error.message))
+    end
+
+    it "responds with MeetingNotFoundError if meeting is not found in database for join" do
+      post bigbluebutton_api_insertDocument_url, params: { meetingID: "test-meeting-1" }
+
+      response_xml = Nokogiri.XML(response.body)
+      expected_error = BBBErrors::MeetingNotFoundError.new
+      expect(response_xml.at_xpath("/response/returncode").text).to(eq("FAILED"))
+      expect(response_xml.at_xpath("/response/messageKey").text).to(eq(expected_error.message_key))
+      expect(response_xml.at_xpath("/response/message").text).to(eq(expected_error.message))
+    end
+
+    it 'forwards the request to the BigBlueButton server' do
+      server = create(:server)
+      meeting = create(:meeting, server: server)
+
+      stub_insert = stub_request(:post, encode_bbb_uri("insertDocument", server.url, server.secret, { meetingID: meeting.id }))
+                    .to_return(body: "<response><returncode>SUCCESS</returncode><message>Presentation is being uploaded</message></response>")
+
+      post bigbluebutton_api_insertDocument_url, params: { meetingID: meeting.id }
+
+      response_xml = Nokogiri.XML(response.body)
+      expect(stub_insert).to have_been_requested
+      expect(response_xml.at_xpath("/response/returncode").text).to eq("SUCCESS")
+    end
+  end
+
   describe '#get_recordings' do
     context 'GET request' do
       context 'verify checksum' do


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

fixes #941 

## Description
<!--- Describe your changes in detail -->
Adds support for the `insertDocument` BigBlueButton Api call: https://docs.bigbluebutton.org/development/api#insertdocument

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Assuming you have a meetingID=random-195645, you can run the following command:
```
curl -s -X POST "http://localhost:4000/bigbluebutton/api/insertDocument?meetingID=random-195645&checksum=7cf422cc7e509f5ac578617e2d057058ce2f091a" --header "Content-Type: application/xml" --data '<modules>
   <module name="presentation">
        <document current="true" downloadable="true" url="{link to download the presentation}" filename="sample.pdf"/>
        <document removable="false" name="sample.pdf"> 
    
JVBERi0xLjQKJdPr6eEKMSAwIG9iago8PC9UaXRsZSAoT3RoZXJfc2FtcGxlKQovUHJvZHVjZXIgKFNraWEvUERGIG0xMDAgR29vZ2xlIERvY3MgUmVuZGVyZXIpPj4KZW5
        </document>
   </module>
</modules>'

```

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
