### PR TITLE
SL-252,SL-248: Add checksum verification to servers, tenants API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -173,6 +173,8 @@ Naming/MethodParameterName:
 Naming/AccessorMethodName:
   Exclude:
     - app/controllers/bigbluebutton_api_controller.rb
+    - app/controllers/api/tenants_controller.rb
+    - app/controllers/api/servers_controller.rb
 
 Naming/PredicateName:
   Exclude:

--- a/app/controllers/api/servers_controller.rb
+++ b/app/controllers/api/servers_controller.rb
@@ -148,9 +148,9 @@ module Api
 
     def set_server
       begin
-        @server = Server.find(params[:id])
+        @server = Server.find(server_id_param[:id])
       rescue ApplicationRedisRecord::RecordNotFound
-        render json: { error: "Couldn't find server with id=#{params[:id]}" }, status: :not_found
+        render json: { error: "Couldn't find server with id=#{server_id_param[:id]}" }, status: :not_found
       end
     end
 
@@ -176,6 +176,10 @@ module Api
 
     def server_panic_params
       params.permit(:keep_state)
+    end
+
+    def server_id_param
+      params.require(:server).permit(:id)
     end
 
     def verify_lb_checksum

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -14,8 +14,11 @@ module ApiHelper
   CHECKSUM_LENGTH_SHA512 = 128
 
   # Verify checksum
-  def verify_checksum
-    secrets = fetch_secrets
+  #
+  # @param [boolean] use_loadbalancer_secret. Set true for API endpoints (such as the tenants API)
+  #     which should be accessed only by superadmins.
+  def verify_checksum(use_loadbalancer_secret = false)
+    secrets = fetch_secrets(use_loadbalancer_secret)
 
     raise ChecksumError if params[:checksum].blank?
     raise ChecksumError if secrets.empty?
@@ -48,8 +51,8 @@ module ApiHelper
     raise ChecksumError
   end
 
-  def fetch_secrets
-    return Rails.configuration.x.loadbalancer_secrets unless Rails.configuration.x.multitenancy_enabled
+  def fetch_secrets(use_loadbalancer_secret = false)
+    return Rails.configuration.x.loadbalancer_secrets unless Rails.configuration.x.multitenancy_enabled && !use_loadbalancer_secret
 
     tenant = fetch_tenant
     if tenant.present?

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -15,10 +15,10 @@ module ApiHelper
 
   # Verify checksum
   #
-  # @param [boolean] use_loadbalancer_secret. Set true for API endpoints (such as the tenants API)
+  # @param [boolean] force_loadbalancer_secret. Set true for API endpoints (such as the tenants API)
   #     which should be accessed only by superadmins.
-  def verify_checksum(use_loadbalancer_secret = false)
-    secrets = fetch_secrets(use_loadbalancer_secret)
+  def verify_checksum(force_loadbalancer_secret = false)
+    secrets = fetch_secrets(force_loadbalancer_secret)
 
     raise ChecksumError if params[:checksum].blank?
     raise ChecksumError if secrets.empty?
@@ -51,8 +51,8 @@ module ApiHelper
     raise ChecksumError
   end
 
-  def fetch_secrets(use_loadbalancer_secret = false)
-    return Rails.configuration.x.loadbalancer_secrets unless Rails.configuration.x.multitenancy_enabled && !use_loadbalancer_secret
+  def fetch_secrets(force_loadbalancer_secret = false)
+    return Rails.configuration.x.loadbalancer_secrets if force_loadbalancer_secret || !Rails.configuration.x.multitenancy_enabled
 
     tenant = fetch_tenant
     if tenant.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,14 +31,14 @@ Rails.application.routes.draw do
   end
 
   scope 'scalelite/api', module: 'api', as: 'scalelite_api' do
-    match '/tenants', to: 'tenants#tenants', via: [:get, :post]
-    post '/tenantInfo', to: 'tenants#tenant_info', as: :tenant_info
+    match '/getTenants', to: 'tenants#get_tenants', as: :get_tenants, via: [:get, :post]
+    post '/getTenantInfo', to: 'tenants#get_tenant_info', as: :get_tenant_info
     post '/addTenant', to: 'tenants#add_tenant', as: :add_tenant
     post '/updateTenant', to: 'tenants#update_tenant', as: :update_tenant
     post '/deleteTenant', to: 'tenants#delete_tenant', as: :delete_tenant
 
-    match '/servers', to: 'servers#servers', via: [:get, :post]
-    post '/serverInfo', to: 'servers#server_info', as: :servers_info
+    match '/getServers', to: 'servers#get_servers', as: :get_servers, via: [:get, :post]
+    post '/getServerInfo', to: 'servers#get_server_info', as: :get_server_info
     post '/addServer', to: 'servers#add_server', as: :add_server
     post '/updateServer', to: 'servers#update_server', as: :update_server
     post '/deleteServer', to: 'servers#delete_server', as: :delete_server

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,14 +30,19 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :api do
-    resources :servers, only: [:index, :show, :create, :update, :destroy] do
-      member do
-        post 'panic'
-      end
-    end
+  scope 'scalelite/api', module: 'api', as: 'scalelite_api' do
+    match '/tenants', to: 'tenants#tenants', via: [:get, :post]
+    post '/tenantInfo', to: 'tenants#tenant_info'
+    post '/addTenant', to: 'tenants#add_tenant'
+    post '/updateTenant', to: 'tenants#update_tenant'
+    post '/deleteTenant', to: 'tenants#delete_tenant'
 
-    resources :tenants, only: [:index, :show, :create, :update, :destroy]
+    match '/servers', to: 'servers#servers', via: [:get, :post]
+    post '/serverInfo', to: 'servers#server_info'
+    post '/addServer', to: 'servers#add_server'
+    post '/updateServer', to: 'servers#update_server'
+    post '/deleteServer', to: 'servers#delete_server'
+    post '/panicServer', to: 'servers#panic_server'
   end
 
   get('health_check', to: 'health_check#index')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,10 +32,10 @@ Rails.application.routes.draw do
 
   scope 'scalelite/api', module: 'api', as: 'scalelite_api' do
     match '/tenants', to: 'tenants#tenants', via: [:get, :post]
-    post '/tenantInfo', to: 'tenants#tenant_info'
-    post '/addTenant', to: 'tenants#add_tenant'
-    post '/updateTenant', to: 'tenants#update_tenant'
-    post '/deleteTenant', to: 'tenants#delete_tenant'
+    post '/tenantInfo', to: 'tenants#tenant_info', as: :tenant_info
+    post '/addTenant', to: 'tenants#add_tenant', as: :add_tenant
+    post '/updateTenant', to: 'tenants#update_tenant', as: :update_tenant
+    post '/deleteTenant', to: 'tenants#delete_tenant', as: :delete_tenant
 
     match '/servers', to: 'servers#servers', via: [:get, :post]
     post '/serverInfo', to: 'servers#server_info'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,11 +38,11 @@ Rails.application.routes.draw do
     post '/deleteTenant', to: 'tenants#delete_tenant', as: :delete_tenant
 
     match '/servers', to: 'servers#servers', via: [:get, :post]
-    post '/serverInfo', to: 'servers#server_info'
-    post '/addServer', to: 'servers#add_server'
-    post '/updateServer', to: 'servers#update_server'
-    post '/deleteServer', to: 'servers#delete_server'
-    post '/panicServer', to: 'servers#panic_server'
+    post '/serverInfo', to: 'servers#server_info', as: :servers_info
+    post '/addServer', to: 'servers#add_server', as: :add_server
+    post '/updateServer', to: 'servers#update_server', as: :update_server
+    post '/deleteServer', to: 'servers#delete_server', as: :delete_server
+    post '/panicServer', to: 'servers#panic_server', as: :panic_server
   end
 
   get('health_check', to: 'health_check#index')

--- a/spec/requests/servers_controller_spec.rb
+++ b/spec/requests/servers_controller_spec.rb
@@ -4,13 +4,18 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::ServersController, type: :controller do
+RSpec.describe Api::ServersController do
   include ApiHelper
 
-  describe 'GET #index' do
+  before do
+    # Disabling the checksum for the specs and re-enable it only when testing specifically the checksum
+    allow_any_instance_of(described_class).to receive(:verify_lb_checksum).and_return(true)
+  end
+
+  describe 'GET #servers' do
     it 'returns a list of configured BigBlueButton servers' do
       servers = create_list(:server, 3)
-      get :index
+      get scalelite_api_servers_url
       expect(response).to have_http_status(:ok)
       server_list = response.parsed_body
       expect(server_list.size).to eq(3)
@@ -32,13 +37,13 @@ RSpec.describe Api::ServersController, type: :controller do
     end
 
     it 'returns a message if no servers are configured' do
-      get :index
+      get scalelite_api_servers_url
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body['error']).to eq('No servers are configured')
     end
   end
 
-  describe 'POST #create' do
+  describe 'POST #addServer' do
     context 'with valid parameters' do
       let(:valid_params) {
         { url: 'https://example.com/bigbluebutton',
@@ -47,7 +52,7 @@ RSpec.describe Api::ServersController, type: :controller do
       }
 
       it 'creates a new BigBlueButton server' do
-        expect { post :create, params: { server: valid_params } }.to change { Server.all.count }.by(1)
+        expect { post scalelite_api_add_server_url, params: { server: valid_params } }.to change { Server.all.count }.by(1)
         expect(response).to have_http_status(:created)
         response_data = response.parsed_body
         server = Server.find(response_data['id'])
@@ -57,7 +62,7 @@ RSpec.describe Api::ServersController, type: :controller do
       end
 
       it 'defaults load_multiplier to 1.0 if not provided' do
-        post :create, params: { server: valid_params.except(:load_multiplier) }
+        post scalelite_api_add_server_url, params: { server: valid_params.except(:load_multiplier) }
         expect(response).to have_http_status(:created)
         server = Server.find(response.parsed_body['id'])
         expect(server.load_multiplier.to_d).to eq(1.0)
@@ -66,24 +71,24 @@ RSpec.describe Api::ServersController, type: :controller do
 
     context 'with invalid parameters' do
       it 'renders an error message if URL is missing' do
-        post :create, params: { server: { url: 'https://example.com/bigbluebutton' } }
+        post scalelite_api_add_server_url, params: { server: { url: 'https://example.com/bigbluebutton' } }
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body['error']).to eq('Server needs a URL and a secret')
       end
 
       it 'renders an error message if secret is missing' do
-        post :create, params: { server: { secret: 'supersecret' } }
+        post scalelite_api_add_server_url, params: { server: { secret: 'supersecret' } }
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body['error']).to eq('Server needs a URL and a secret')
       end
     end
   end
 
-  describe 'PUT #update' do
+  describe 'PUT #updateServer' do
     context 'when updating state' do
       it 'updates the server state to "enabled"' do
         server = create(:server)
-        put :update, params: { id: server.id, server: { state: 'enable' } }
+        post scalelite_api_update_server_url, params: { server: { id: server.id, state: 'enable' } }
         updated_server = Server.find(server.id) # Reload
         expect(updated_server.state).to eq('enabled')
         expect(response).to have_http_status(:ok)
@@ -93,7 +98,7 @@ RSpec.describe Api::ServersController, type: :controller do
 
       it 'updates the server state to "cordoned"' do
         server = create(:server)
-        put :update, params: { id: server.id, server: { state: 'cordon' } }
+        post scalelite_api_update_server_url, params: { server: { id: server.id, state: 'cordon' } }
         updated_server = Server.find(server.id) # Reload
         expect(updated_server.state).to eq('cordoned')
         expect(response).to have_http_status(:ok)
@@ -103,7 +108,7 @@ RSpec.describe Api::ServersController, type: :controller do
 
       it 'updates the server state to "disabled"' do
         server = create(:server)
-        put :update, params: { id: server.id, server: { state: 'disable' } }
+        post scalelite_api_update_server_url, params: { server: { id: server.id, state: 'disable' } }
         updated_server = Server.find(server.id) # Reload
         expect(updated_server.state).to eq('disabled')
         expect(response).to have_http_status(:ok)
@@ -113,7 +118,7 @@ RSpec.describe Api::ServersController, type: :controller do
 
       it 'returns an error for an invalid state parameter' do
         server = create(:server)
-        put :update, params: { id: server.id, server: { state: 'invalid_state' } }
+        post scalelite_api_update_server_url, params: { server: { id: server.id, state: 'invalid_state' } }
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body['error']).to eq("Invalid state parameter: invalid_state")
       end
@@ -122,7 +127,7 @@ RSpec.describe Api::ServersController, type: :controller do
     context 'when updating load_multiplier' do
       it 'updates the server load_multiplier' do
         server = create(:server)
-        put :update, params: { id: server.id, server: { load_multiplier: '2.5' } }
+        post scalelite_api_update_server_url, params: { server: { id: server.id, load_multiplier: '2.5' } }
         updated_server = Server.find(server.id) # Reload
         expect(updated_server.load_multiplier).to eq("2.5")
         expect(response).to have_http_status(:ok)
@@ -132,18 +137,18 @@ RSpec.describe Api::ServersController, type: :controller do
 
       it 'returns an error for an invalid load_multiplier parameter' do
         server = create(:server)
-        put :update, params: { id: server.id, server: { load_multiplier: 0 } }
+        post scalelite_api_update_server_url, params: { server: { id: server.id, load_multiplier: 0 } }
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body['error']).to eq("Load-multiplier must be a non-zero number")
       end
     end
   end
 
-  describe 'DELETE #destroy' do
+  describe 'DELETE #deleteServer' do
     context 'with an existing server' do
       it 'deletes the server' do
         server = create(:server)
-        expect { delete :destroy, params: { id: server.id } }.to change { Server.all.count }.by(-1)
+        expect { post scalelite_api_delete_server_url, params: { server: { id: server.id } } }.to change { Server.all.count }.by(-1)
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['success']).to eq("Server id=#{server.id} was destroyed")
       end
@@ -151,14 +156,14 @@ RSpec.describe Api::ServersController, type: :controller do
 
     context 'with a non-existent server' do
       it 'does not delete any server' do
-        delete :destroy, params: { id: 'nonexistent-id' }
+        post scalelite_api_delete_server_url, params: { server: { id: 'nonexistent-id' } }
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body['error']).to eq("Couldn't find server with id=nonexistent-id")
       end
     end
   end
 
-  describe 'POST #panic' do
+  describe 'POST #panicServer' do
     it 'marks the server as unavailable and clears all meetings from it' do
       server = create(:server)
       meeting1 = create(:meeting, server: server)
@@ -184,7 +189,7 @@ RSpec.describe Api::ServersController, type: :controller do
         .to_return(body: "<response><returncode>SUCCESS</returncode><messageKey>OK</messageKey>
                       <message>The meeting was ended successfully.</message></response>")
 
-      post :panic, params: { id: server.id }
+      post scalelite_api_panic_server_url, params: { server: { id: server.id } }
 
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
@@ -197,7 +202,7 @@ RSpec.describe Api::ServersController, type: :controller do
     it 'keeps server state if keep_state is true' do
       server = create(:server, state: 'enabled')
 
-      post :panic, params: { id: server.id, keep_state: true }
+      post scalelite_api_panic_server_url, params: { server: { id: server.id }, keep_state: true }
 
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
@@ -208,7 +213,7 @@ RSpec.describe Api::ServersController, type: :controller do
     end
 
     it 'returns an error message if the server is not found' do
-      post :panic, params: { id: 'nonexistent_id' }
+      post scalelite_api_panic_server_url, params: { server: { id: 'nonexistent_id' } }
 
       expect(response).to have_http_status(:not_found)
       json = response.parsed_body

--- a/spec/requests/tenants_controller_spec.rb
+++ b/spec/requests/tenants_controller_spec.rb
@@ -2,10 +2,15 @@
 
 require 'rails_helper'
 
-RSpec.describe Api::TenantsController, type: :controller do
+RSpec.describe Api::TenantsController do
   include ApiHelper
 
-  describe 'GET #index' do
+  before do
+    # Disabling the checksum for the specs and re-enable it only when testing specifically the checksum
+    allow_any_instance_of(described_class).to receive(:verify_lb_checksum).and_return(true)
+  end
+
+  describe 'GET #tenants' do
     context 'with multitenancy enabled' do
       before do
         Rails.configuration.x.multitenancy_enabled = true
@@ -13,7 +18,7 @@ RSpec.describe Api::TenantsController, type: :controller do
 
       it 'returns a list of all tenants' do
         tenants = create_list(:tenant, 3)
-        get :index
+        get scalelite_api_tenants_url
         expect(response).to have_http_status(:ok)
         tenants_list = response.parsed_body
         expect(tenants_list.size).to eq(3)
@@ -27,7 +32,7 @@ RSpec.describe Api::TenantsController, type: :controller do
       end
 
       it 'returns a message if there are no tenants' do
-        get :index
+        get scalelite_api_tenants_url
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['message']).to eq('No tenants exist')
       end
@@ -36,21 +41,21 @@ RSpec.describe Api::TenantsController, type: :controller do
     context 'with multitenancy disabled' do
       it 'returns nil if multitenancy is disabled' do
         Rails.configuration.x.multitenancy_enabled = false
-        get :index
+        get scalelite_api_tenants_url
         expect(response).to have_http_status(:precondition_failed)
         expect(response.parsed_body['message']).to eq('Multitenancy is disabled')
       end
     end
   end
 
-  describe 'GET #show' do
+  describe 'POST #tenant_info' do
     before do
       Rails.configuration.x.multitenancy_enabled = true
     end
 
     it 'returns the tenant associated with the given ID' do
       tenant = create(:tenant)
-      get :show, params: { id: tenant.id }
+      post scalelite_api_tenant_info_url, params: { tenant: { id: tenant.id } }
       expect(response).to have_http_status(:ok)
       returned_tenant = response.parsed_body
       expect(returned_tenant['name']).to eq(tenant.name)
@@ -58,13 +63,13 @@ RSpec.describe Api::TenantsController, type: :controller do
     end
 
     it 'renders an error message if the tenant was not found' do
-      get :show, params: { id: 'nonexistent-id' }
+      post scalelite_api_tenant_info_url, params: { tenant: { id: 'nonexistent-id' } }
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body['error']).to eq("Couldn't find Tenant with id=nonexistent-id")
     end
   end
 
-  describe 'POST #create' do
+  describe 'POST #add_tenant' do
     before do
       Rails.configuration.x.multitenancy_enabled = true
     end
@@ -76,37 +81,37 @@ RSpec.describe Api::TenantsController, type: :controller do
       }
 
       it 'creates a new tenant' do
-        expect { post :create, params: { tenant: valid_params } }.to change { Tenant.all.count }.by(1)
+        expect { post scalelite_api_add_tenant_url, params: { tenant: valid_params } }.to change { Tenant.all.count }.by(1)
         expect(response).to have_http_status(:created)
         response_data = response.parsed_body
-        expect(response_data['id']).to be_present
+        expect(response_data['tenant']['id']).to be_present
       end
     end
 
     context 'with invalid parameters' do
       it 'renders an error message if name is missing' do
-        post :create, params: { tenant: { secrets: 'test-secret' } }
+        post scalelite_api_add_tenant_url, params: { tenant: { secrets: 'test-secret' } }
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body['message']).to eq('Error: both name and secrets are required to create a Tenant')
       end
 
       it 'renders an error message if secret is missing' do
-        post :create, params: { tenant: { name: 'test-name' } }
+        post scalelite_api_add_tenant_url, params: { tenant: { name: 'test-name' } }
         expect(response).to have_http_status(:bad_request)
         expect(response.parsed_body['message']).to eq('Error: both name and secrets are required to create a Tenant')
       end
     end
   end
 
-  describe 'PATCH #update' do
+  describe 'POST #update_tenant' do
     before do
       Rails.configuration.x.multitenancy_enabled = true
     end
 
     it 'updates a tenant name' do
       tenant = create(:tenant)
-      new_tenant_params = { name: 'new-name' }
-      patch :update, params: { id: tenant.id, tenant: new_tenant_params }
+      new_tenant_params = { id: tenant.id, name: 'new-name' }
+      post scalelite_api_update_tenant_url, params: { tenant: new_tenant_params }
       expect(response).to have_http_status(:ok)
       expect(Tenant.find(tenant.id).name).to eq('new-name') # check that the id-> name index was updated
       expect(Tenant.find_by_name('new-name')).not_to be_nil # check that the new name->id index has been added
@@ -115,14 +120,14 @@ RSpec.describe Api::TenantsController, type: :controller do
 
     it 'updates a tenant secret' do
       tenant = create(:tenant)
-      new_tenant_params = { secrets: 'new-secret' }
-      patch :update, params: { id: tenant.id, tenant: new_tenant_params }
+      new_tenant_params = { id: tenant.id, secrets: 'new-secret' }
+      post scalelite_api_update_tenant_url, params: { tenant: new_tenant_params }
       expect(response).to have_http_status(:ok)
       expect(Tenant.find(tenant.id).secrets).to eq('new-secret') # check that the id-> secret index was updated
     end
   end
 
-  describe 'DELETE #destroy' do
+  describe 'POST #delete_tenant' do
     before do
       Rails.configuration.x.multitenancy_enabled = true
     end
@@ -130,7 +135,7 @@ RSpec.describe Api::TenantsController, type: :controller do
     context 'with an existing tenant' do
       it 'deletes the tenant' do
         tenant = create(:tenant)
-        expect { delete :destroy, params: { id: tenant.id } }.to change { Tenant.all.count }.by(-1)
+        expect { post scalelite_api_delete_tenant_url, params: { tenant: { id: tenant.id } } }.to change { Tenant.all.count }.by(-1)
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['id']).to eq(tenant.id)
       end
@@ -138,7 +143,7 @@ RSpec.describe Api::TenantsController, type: :controller do
 
     context 'with a non-existent tenant' do
       it 'does not delete any tenant' do
-        delete :destroy, params: { id: 'nonexistent-id' }
+        post scalelite_api_delete_tenant_url, params: { tenant: { id: 'nonexistent-id' } }
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body['error']).to eq("Couldn't find Tenant with id=nonexistent-id")
       end

--- a/spec/requests/tenants_controller_spec.rb
+++ b/spec/requests/tenants_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::TenantsController do
 
   before do
     # Disabling the checksum for the specs and re-enable it only when testing specifically the checksum
-    allow_any_instance_of(described_class).to receive(:verify_lb_checksum).and_return(true)
+    allow_any_instance_of(described_class).to receive(:verify_checksum).and_return(true)
   end
 
   describe 'GET #tenants' do
@@ -18,7 +18,7 @@ RSpec.describe Api::TenantsController do
 
       it 'returns a list of all tenants' do
         tenants = create_list(:tenant, 3)
-        get scalelite_api_tenants_url
+        get scalelite_api_get_tenants_url
         expect(response).to have_http_status(:ok)
         tenants_list = response.parsed_body
         expect(tenants_list.size).to eq(3)
@@ -32,7 +32,7 @@ RSpec.describe Api::TenantsController do
       end
 
       it 'returns a message if there are no tenants' do
-        get scalelite_api_tenants_url
+        get scalelite_api_get_tenants_url
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['message']).to eq('No tenants exist')
       end
@@ -41,7 +41,7 @@ RSpec.describe Api::TenantsController do
     context 'with multitenancy disabled' do
       it 'returns nil if multitenancy is disabled' do
         Rails.configuration.x.multitenancy_enabled = false
-        get scalelite_api_tenants_url
+        get scalelite_api_get_tenants_url
         expect(response).to have_http_status(:precondition_failed)
         expect(response.parsed_body['message']).to eq('Multitenancy is disabled')
       end
@@ -55,15 +55,16 @@ RSpec.describe Api::TenantsController do
 
     it 'returns the tenant associated with the given ID' do
       tenant = create(:tenant)
-      post scalelite_api_tenant_info_url, params: { tenant: { id: tenant.id } }
+      post scalelite_api_get_tenant_info_url, params: { id: tenant.id }
       expect(response).to have_http_status(:ok)
+      puts("response: #{response.parsed_body}")
       returned_tenant = response.parsed_body
       expect(returned_tenant['name']).to eq(tenant.name)
       expect(returned_tenant['secrets']).to eq(tenant.secrets)
     end
 
     it 'renders an error message if the tenant was not found' do
-      post scalelite_api_tenant_info_url, params: { tenant: { id: 'nonexistent-id' } }
+      post scalelite_api_get_tenant_info_url, params: { id: 'nonexistent-id' }
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body['error']).to eq("Couldn't find Tenant with id=nonexistent-id")
     end
@@ -110,8 +111,8 @@ RSpec.describe Api::TenantsController do
 
     it 'updates a tenant name' do
       tenant = create(:tenant)
-      new_tenant_params = { id: tenant.id, name: 'new-name' }
-      post scalelite_api_update_tenant_url, params: { tenant: new_tenant_params }
+      new_tenant_params = { name: 'new-name' }
+      post scalelite_api_update_tenant_url, params: { id: tenant.id, tenant: new_tenant_params }
       expect(response).to have_http_status(:ok)
       expect(Tenant.find(tenant.id).name).to eq('new-name') # check that the id-> name index was updated
       expect(Tenant.find_by_name('new-name')).not_to be_nil # check that the new name->id index has been added
@@ -120,8 +121,8 @@ RSpec.describe Api::TenantsController do
 
     it 'updates a tenant secret' do
       tenant = create(:tenant)
-      new_tenant_params = { id: tenant.id, secrets: 'new-secret' }
-      post scalelite_api_update_tenant_url, params: { tenant: new_tenant_params }
+      new_tenant_params = { secrets: 'new-secret' }
+      post scalelite_api_update_tenant_url, params: { id: tenant.id, tenant: new_tenant_params }
       expect(response).to have_http_status(:ok)
       expect(Tenant.find(tenant.id).secrets).to eq('new-secret') # check that the id-> secret index was updated
     end
@@ -135,7 +136,7 @@ RSpec.describe Api::TenantsController do
     context 'with an existing tenant' do
       it 'deletes the tenant' do
         tenant = create(:tenant)
-        expect { post scalelite_api_delete_tenant_url, params: { tenant: { id: tenant.id } } }.to change { Tenant.all.count }.by(-1)
+        expect { post scalelite_api_delete_tenant_url, params: { id: tenant.id } }.to change { Tenant.all.count }.by(-1)
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body['id']).to eq(tenant.id)
       end
@@ -143,7 +144,7 @@ RSpec.describe Api::TenantsController do
 
     context 'with a non-existent tenant' do
       it 'does not delete any tenant' do
-        post scalelite_api_delete_tenant_url, params: { tenant: { id: 'nonexistent-id' } }
+        post scalelite_api_delete_tenant_url, params: { id: 'nonexistent-id' }
         expect(response).to have_http_status(:not_found)
         expect(response.parsed_body['error']).to eq("Couldn't find Tenant with id=nonexistent-id")
       end
@@ -152,7 +153,7 @@ RSpec.describe Api::TenantsController do
 
   describe 'verify_checksum' do
     before do
-      allow_any_instance_of(described_class).to receive(:verify_lb_checksum).and_call_original
+      allow_any_instance_of(described_class).to receive(:verify_checksum).and_call_original
     end
 
     it 'successfully creates a tenant with checksum value computed using SHA1' do


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the tenants and servers API to match the format for BBB, and added a checksum verification. 
The checksum must be computed with the LOADBALANCER_SECRET rather than the tenant's secret(s), so that tenants do not have access to all tenant and server information.

## Testing Steps
Use API Mate to create the custom calls. 

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
