### PR TITLE
Option for default presentations

### DIFF
--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -207,11 +207,9 @@ class BigBlueButtonApiController < ApplicationController
     excluded_params = Rails.configuration.x.create_exclude_params
     # Pass along all params except the built in rails ones and excluded_params
     uri = encode_bbb_uri('create', server.url, server.secret, pass_through_params(excluded_params))
+    body = request.post? ? request.body.read : override_default_presentations
 
     begin
-      # Read the body if POST
-      body = request.post? ? request.body.read : ''
-
       # Send a GET/POST request to the server
       response = get_post_req(uri, body, **bbb_req_timeout(server))
     rescue BBBError

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -207,7 +207,7 @@ class BigBlueButtonApiController < ApplicationController
     excluded_params = Rails.configuration.x.create_exclude_params
     # Pass along all params except the built in rails ones and excluded_params
     uri = encode_bbb_uri('create', server.url, server.secret, pass_through_params(excluded_params))
-    body = request.post? ? request.body.read : override_default_presentations
+    body = request.post? ? request.body.read : generate_default_presentations
 
     begin
       # Send a GET/POST request to the server

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -218,7 +218,8 @@ module ApiHelper
   end
 end
 
-def override_default_presentations
+def generate_default_presentations
+  return '' if Rails.configuration.x.default_presentations.empty?
   doc = Nokogiri::XML('<modules></modules>')
   module_pres = Nokogiri::XML::Node.new("module", doc)
   module_pres['name'] = "presentation"

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -217,3 +217,18 @@ module ApiHelper
     final_params
   end
 end
+
+def override_default_presentations
+  doc = Nokogiri::XML('<modules></modules>')
+  module_pres = Nokogiri::XML::Node.new("module", doc)
+  module_pres['name'] = "presentation"
+
+  Rails.configuration.x.default_presentations.each { |x|
+    document = Nokogiri::XML::Node.new("document", doc)
+    document['url'] = x[0]
+    document['filename'] = x[1]
+    module_pres << document
+  }
+  doc.root << module_pres
+  doc.to_xml
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -138,6 +138,8 @@ module Scalelite
 
     config.i18n.default_locale = ENV.fetch('DEFAULT_LOCALE', 'en')
 
+    config.x.default_presentations = ENV.fetch('DEFAULT_PRESENTATIONS', '').split(",").collect { |x| x.split('->') }
+
     # Comma separated list of create params that can be overridden by the client
     config.x.default_create_params = ENV.fetch('DEFAULT_CREATE_PARAMS', '')
                                         .split(',').to_h { |param| param.split('=', 2) }.symbolize_keys

--- a/docs/configuration-README.md
+++ b/docs/configuration-README.md
@@ -59,6 +59,7 @@ These variables are used by the service startup scripts in the Docker images, bu
 * `OVERRIDE_CREATE_PARAMS`: Sets a list of params on the create call that CANNOT be overridden by the client/requester. Should be in the format 'OVERRIDE_CREATE_PARAMS=param1=param1value,param2=param2value'
 * `DEFAULT_JOIN_PARAMS`: Sets a list of default params on the join call that CAN be overridden by the client/requester. Should be in the format 'DEFAULT_JOIN_PARAMS=param1=param1value,param2=param2value'
 * `OVERRIDE_JOIN_PARAMS`: Sets a list of  params on the create call that CANNOT be overridden by the client/requester. Should be in the format 'OVERRIDE_JOIN_PARAMS=param1=param1value,param2=param2value'
+* `DEFAULT_PRESENTATIONS`: Sets a list of default presentations on the create call. Will only trigger when a GET-request is used, otherwise the supplied body will be used. Should be in the format 'DEFAULT_PRESENTATIONS=http://presurl->presname.pdf,http://presurl2->presname2.pdf'
 * `GET_RECORDINGS_API_FILTERED`: Prevent get_recordings api from returning all recordings when recordID is not specified in the request, by setting value to 'true'. Defaults to false.
 * `PREPARED_STATEMENT`: Enable/Disable Active Record prepared statements feature, can be disabled by setting the value as `false`. Defaults to `true`.
 * `DB_CONNECTION_RETRY_COUNT`: The number of times db connection retries will be attempted, in case of a db connection failure. Defaults to `3`.


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request adds the option to supply default presentations on the `create`-call. This is a good addition to the default params / override options.

When submitting a `POST`-request as `create`-call, the supplied body will be used. If there is no body supplied or it is initially a `GET`-request, the default presentations will be added.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Set the following inside your environment:
```env
DEFAULT_PRESENTATIONS: "https://test.bigbluebutton.org/default.pdf->default_1.pdf,https://test.bigbluebutton.org/default.pdf->default_2.pdf"
```
This will download the default BBB-presentation two times, with two different names to showcase the options.
`->` is the separator of URL and name because this is unlikely to appear inside an URL. Also with that, it is possible to add `base64`-presentations in the future.

