### PR TITLE
Option for default presentations on tenants

### DIFF
--- a/app/controllers/api/tenants_controller.rb
+++ b/app/controllers/api/tenants_controller.rb
@@ -84,12 +84,14 @@ module Api
     #   "id": String        # Required
     #   "tenant": {
     #     "name": String,     # include the parameter you want updated
-    #     "secrets": String
+    #     "secrets": String,
+    #     "default_presentations": String
     #   }
     # }
     def update_tenant
       @tenant.name = tenant_params[:name] if tenant_params[:name].present?
       @tenant.secrets = tenant_params[:secrets] if tenant_params[:secrets].present?
+      @tenant.default_presentations = tenant_params[:default_presentations] if tenant_params[:default_presentations].present?
       @tenant.save!
       render json: { tenant: @tenant }, status: :ok
     rescue ApplicationRedisRecord::RecordNotSaved => e
@@ -117,7 +119,7 @@ module Api
     end
 
     def tenant_params
-      params.require(:tenant).permit(:name, :secrets)
+      params.require(:tenant).permit(:name, :secrets, :default_presentations)
     end
 
     def check_multitenancy

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -212,6 +212,9 @@ class BigBlueButtonApiController < ApplicationController
       # Read the body if POST
       body = request.post? ? request.body.read : ''
 
+      # Override body with default presentations if empty
+      body = generate_tenant_presentations unless body != ''
+
       # Send a GET/POST request to the server
       response = get_post_req(uri, body, **bbb_req_timeout(server))
     rescue BBBError

--- a/app/controllers/concerns/api_helper.rb
+++ b/app/controllers/concerns/api_helper.rb
@@ -217,3 +217,23 @@ module ApiHelper
     final_params
   end
 end
+
+def generate_tenant_presentations
+  tenant = fetch_tenant
+  if tenant.present?
+    return '' if tenant.default_presentations_array.empty?
+    doc = Nokogiri::XML('<modules></modules>')
+    module_pres = Nokogiri::XML::Node.new("module", doc)
+    module_pres['name'] = "presentation"
+    tenant.default_presentations_array.each { |x|
+      document = Nokogiri::XML::Node.new("document", doc)
+      document['url'] = x[0]
+      document['filename'] = x[1]
+      module_pres << document
+    }
+    doc.root << module_pres
+    doc.to_xml
+  else
+    ''
+  end
+end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -14,7 +14,7 @@ class Tenant < ApplicationRedisRecord
   # Shared secrets for making API requests for this tenant (: separated)
   application_redis_attr :secrets
 
-  # Shared secrets for making API requests for this tenant (: separated)
+  # Default presentations for this tenant (Sceme: URL->name;URL2->name2)
   application_redis_attr :default_presentations
 
   def save!

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -3,7 +3,7 @@
 class Tenant < ApplicationRedisRecord
   SECRETS_SEPARATOR = ':'
 
-  define_attribute_methods :id, :name, :secrets
+  define_attribute_methods :id, :name, :secrets, :default_presentations
 
   # Unique ID for this tenant
   application_redis_attr :id
@@ -13,6 +13,9 @@ class Tenant < ApplicationRedisRecord
 
   # Shared secrets for making API requests for this tenant (: separated)
   application_redis_attr :secrets
+
+  # Shared secrets for making API requests for this tenant (: separated)
+  application_redis_attr :default_presentations
 
   def save!
     with_connection do |redis|
@@ -34,6 +37,7 @@ class Tenant < ApplicationRedisRecord
           pipeline.del(old_names_key) if !id_changed? && name_changed? # Delete the old name key if it's not a new record and the name was updated
           pipeline.hset(id_key, 'name', name) if name_changed?
           pipeline.hset(id_key, 'secrets', secrets) if secrets_changed?
+          pipeline.hset(id_key, 'default_presentations', default_presentations) if default_presentations_changed?
           pipeline.sadd?('tenants', id) if id_changed?
         end
       end
@@ -113,6 +117,10 @@ class Tenant < ApplicationRedisRecord
 
     # Superclass bookkeeping
     super
+  end
+
+  def default_presentations_array
+    default_presentations.blank? ? [] : default_presentations.split(";").collect { |x| x.split('->') }
   end
 
   def secrets_array

--- a/docs/rake-README.md
+++ b/docs/rake-README.md
@@ -473,10 +473,19 @@ When you run this command, Scalelite will return a list of all tenants, along wi
 id: 9a870f45-ec23-4d29-828b-4673f3536d7b
         name: tenant1
         secrets: secret1
+        default presentations: 0
 id: 4f3e4bb8-2a4e-41a6-9af8-0678c651777f
         name: tenant2
         secrets: secret2:secret2a:secret2b
+        default presentations: 1
+                https://test.bigbluebutton.org/default.pdf -> default.pdf
 ```
+
+#### Set default presentations for a tenant
+`./bin/rake tenants:presentations[id,"http://url_to_pres.pdf->default.pdf;http://another_pres.pdf->default_2.pdf"]`
+
+To clear the default presentations, simply omit the pres-param.
+
 #### Associate Old Recordings with a Tenant
 `./bin/rake recordings:addToTenant[tenant-id]`
 

--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -14,6 +14,10 @@ task tenants: :environment do |_t, _args|
       puts("id: #{tenant.id}")
       puts("\tname: #{tenant.name}")
       puts("\tsecrets: #{tenant.secrets}")
+      puts("\tdefault presentations: #{tenant.default_presentations_array.length}")
+      tenant.default_presentations_array.each { |x|
+        puts("\t\t#{x[0]} -> #{x[1]}")
+      }
     end
   end
 
@@ -53,6 +57,25 @@ namespace :tenants do
     tenant = Tenant.find(id)
     tenant.name = name if name.present?
     tenant.secrets = secrets if secrets.present?
+    tenant.save!
+
+    puts('OK')
+    puts("Updated Tenant id: #{tenant.id}")
+  end
+
+  desc 'Set default presentations for an existing Tenant'
+  task :presentations, [:id, :pres] => :environment do |_t, args|
+    check_multitenancy
+    id = args[:id]
+    pres = args[:pres]
+
+    if id.blank?
+      puts('Error: id is required to update a Tenant')
+      exit(1)
+    end
+
+    tenant = Tenant.find(id)
+    tenant.default_presentations = (pres.presence || '')
     tenant.save!
 
     puts('OK')


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds the option to supply default presentations on the create-call on a per-tenant basis. This is a good addition to the default params / override options.

When submitting a POST-request as create-call, the supplied body will be used. If there is no body supplied or it is initially a GET-request, the default presentations for the current tenant will be added.

This PR is independent from #965. I suggest merging the other one first.
## Testing Steps
1. Add a tenant
2. Add default presentations for this tenant:
```bash
./bin/rake tenants:presentations[<id>,"https://test.bigbluebutton.org/default.pdf->default_1.pdf;https://test.bigbluebutton.org/default.pdf->default_2.pdf"]
```
3. Create a meeting and see the default presentations.
