### PR TITLE
delete source tar if transfer is successful only

### DIFF
--- a/bigbluebutton/scalelite_post_publish.rb
+++ b/bigbluebutton/scalelite_post_publish.rb
@@ -85,5 +85,4 @@ begin
   File.write("#{recording_dir}/status/published/#{meeting_id}-sender.done", "Published #{meeting_id}")
 
   puts('Recording transferring to Scalelite ends')
-
 end

--- a/bigbluebutton/scalelite_post_publish.rb
+++ b/bigbluebutton/scalelite_post_publish.rb
@@ -72,7 +72,7 @@ begin
   end
 
   puts("Transferring recording archive to #{spool_dir}")
-  system('rsync', '--verbose', '--protect-args', *extra_rsync_opts, archive_file, spool_dir) \
+  system('rsync', '--verbose', '--remove-source-files', '--protect-args', *extra_rsync_opts, archive_file, spool_dir) \
     || raise('Failed to transfer recording archive')
 
   # Delete recording after transfer
@@ -85,6 +85,5 @@ begin
   File.write("#{recording_dir}/status/published/#{meeting_id}-sender.done", "Published #{meeting_id}")
 
   puts('Recording transferring to Scalelite ends')
-ensure
-  FileUtils.rm_f(archive_file)
+
 end


### PR DESCRIPTION
## Description
current script removes tar even if transfer failed. using rsync option we have possibility to remove source in case transfer is successful only. if failed we can transfer failed tars later.

## Testing Steps
make test record with disconnected shared storage or temporary disabled destination.
<meeting_id.tar> file should stay in work_dir: /var/bigbluebutton/recording/scalelite

if destination is available tar file is not present in work_dir: /var/bigbluebutton/recording/scalelite after transfer.


