### PR TITLE
[SL-XX] update redis-namespace to version 1.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'puma', '~> 6.2', '>= 6.2.1'
 # Redis connection setup for live session (server and meeting) tracking
 gem 'connection_pool', '~> 2.4.0'
 gem 'redis', '~> 4.8.0'
-gem 'redis-namespace', '~> 1.10.0'
+gem 'redis-namespace', '~> 1.11.0'
 
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 1.4.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.8.1)
-    redis-namespace (1.10.0)
+    redis-namespace (1.11.0)
       redis (>= 4)
     regexp_parser (2.7.0)
     rexml (3.2.5)
@@ -269,7 +269,7 @@ DEPENDENCIES
   rails (~> 6.1, >= 6.1.7.3)
   rails-controller-testing
   redis (~> 4.8.0)
-  redis-namespace (~> 1.10.0)
+  redis-namespace (~> 1.11.0)
   rspec-rails (~> 5.1.2)
   rubocop (~> 1.50.0)
   rubocop-performance

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -118,7 +118,7 @@ class Meeting < ApplicationRedisRecord
     with_connection do |redis|
       redis.multi do |transaction|
         transaction.del(key)
-        transaction.srem('meetings', id)
+        transaction.srem?('meetings', id)
         transaction.hdel('voice_bridges', voice_bridge) unless voice_bridge.nil?
       end
     end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -133,7 +133,7 @@ class Server < ApplicationRedisRecord
     if state_changed?
       redis.zadd('cordoned_server_load', self.load, id) if self.load.present?
       redis.zrem('server_load', id)
-      redis.srem('server_enabled', id)
+      redis.srem?('server_enabled', id)
     end
     return unless load_changed?
 
@@ -147,7 +147,7 @@ class Server < ApplicationRedisRecord
   def handle_disabled_state(redis)
     return unless state_changed?
 
-    redis.srem('server_enabled', id)
+    redis.srem?('server_enabled', id)
     redis.zrem('server_load', id)
     redis.zrem('cordoned_server_load', id)
   end
@@ -157,7 +157,7 @@ class Server < ApplicationRedisRecord
       if enabled
         redis.sadd?('server_enabled', id)
       else
-        redis.srem('server_enabled', id)
+        redis.srem?('server_enabled', id)
         redis.zrem('server_load', id)
       end
     end
@@ -178,9 +178,9 @@ class Server < ApplicationRedisRecord
 
       redis.multi do |pipeline|
         pipeline.del(key)
-        pipeline.srem('servers', id)
+        pipeline.srem?('servers', id)
         pipeline.zrem('server_load', id)
-        pipeline.srem('server_enabled', id)
+        pipeline.srem?('server_enabled', id)
         pipeline.zrem('cordoned_server_load', id)
       end
     end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -107,7 +107,7 @@ class Tenant < ApplicationRedisRecord
       redis.multi do |transaction|
         transaction.del(key)
         transaction.del(name_key)
-        transaction.srem('tenants', id)
+        transaction.srem?('tenants', id)
       end
     end
 

--- a/spec/models/server_spec.rb
+++ b/spec/models/server_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Server, redis: true do
       context 'with lowest load and state as enabled' do
         before do
           RedisStore.with_connection do |redis|
-            redis.flushall
+            redis.redis.flushall
             redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                state: 'enabled')
             redis.sadd?('servers', 'test-1')


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the redis-namespace gem from version 1.10 to version 1.11.0. This update allows for redis' srem function to be updated to srem?, which will remove the associated warnings in the logs.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
