### PR TITLE
Fix recording ready notifier in multitenancy

### DIFF
--- a/app/services/recording_ready_notifier_service.rb
+++ b/app/services/recording_ready_notifier_service.rb
@@ -5,6 +5,8 @@ require 'net/http'
 
 class RecordingReadyNotifierService
   class << self
+    include ApiHelper
+
     def execute(recording_id)
       recording = Recording.find(recording_id)
       meeting_id = recording.meeting_id

--- a/spec/services/recording_ready_notifier_service_spec.rb
+++ b/spec/services/recording_ready_notifier_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RecordingReadyNotifierService, type: :service do
+  let!(:recording) { create(:recording) }
+  let(:url) { 'https://test-1.example.com/bigbluebutton/api/' }
+  let!(:callback_data) do
+    create(:callback_data,
+           meeting_id: recording.meeting_id,
+           recording_id: recording.id,
+           callback_attributes: { recording_ready_url: 'https://test-1.example.com/bigbluebutton/api/' })
+  end
+
+  it 'returns true if recording ready notification succeeds' do
+    stub_request(:post, url)
+      .to_return(status: 200, body: '', headers: {})
+
+    allow(JWT).to receive(:encode).and_return('eyJhbGciOiJIUzI1NiJ9.eyJtZWV0aW5nX2lkIjoibWVldGluZzE5In0.Jlw1ND63QJ3j9TT0mgp_5fpmPA82FhMT_-mPU25PEFY')
+    return_val = RecordingReadyNotifierService.execute(recording.id)
+
+    expect(return_val).to be true
+  end
+
+  it 'returns false if recording ready notification fails' do
+    stub_request(:post, url).to_timeout
+
+    allow(JWT).to receive(:encode).and_return('eyJhbGciOiJIUzI1NiJ9.eyJtZWV0aW5nX2lkIjoibWVldGluZzE5In0.Jlw1ND63QJ3j9TT0mgp_5fpmPA82FhMT_-mPU25PEFY')
+    return_val = RecordingReadyNotifierService.execute(recording.id)
+
+    expect(return_val).to be false
+  end
+
+  context 'multitenancy' do
+    let!(:tenant) { create(:tenant, name: 'bn') }
+
+    before do
+      Rails.configuration.x.multitenancy_enabled = true
+
+      allow_any_instance_of(ApiHelper).to receive(:fetch_secrets).and_return(tenant.secrets_array)
+    end
+
+    it 'encodes the payload using the tenants secret' do
+      stub_request(:post, url)
+        .to_return(status: 200, body: '', headers: {})
+
+      expect(JWT).to receive(:encode).and_return(JWT.encode({ meeting_id: recording.meeting_id, record_id: recording.id }, tenant.secrets_array[0]))
+
+      RecordingReadyNotifierService.execute(recording.id)
+    end
+  end
+end

--- a/spec/services/recording_ready_notifier_service_spec.rb
+++ b/spec/services/recording_ready_notifier_service_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe RecordingReadyNotifierService, type: :service do
+  before do
+    Rails.configuration.x.multitenancy_enabled = false
+  end
+
   let!(:recording) { create(:recording) }
   let(:url) { 'https://test-1.example.com/bigbluebutton/api/' }
   let!(:callback_data) do
@@ -17,7 +21,7 @@ RSpec.describe RecordingReadyNotifierService, type: :service do
       .to_return(status: 200, body: '', headers: {})
 
     allow(JWT).to receive(:encode).and_return('eyJhbGciOiJIUzI1NiJ9.eyJtZWV0aW5nX2lkIjoibWVldGluZzE5In0.Jlw1ND63QJ3j9TT0mgp_5fpmPA82FhMT_-mPU25PEFY')
-    return_val = RecordingReadyNotifierService.execute(recording.id)
+    return_val = described_class.execute(recording.id)
 
     expect(return_val).to be true
   end
@@ -26,7 +30,7 @@ RSpec.describe RecordingReadyNotifierService, type: :service do
     stub_request(:post, url).to_timeout
 
     allow(JWT).to receive(:encode).and_return('eyJhbGciOiJIUzI1NiJ9.eyJtZWV0aW5nX2lkIjoibWVldGluZzE5In0.Jlw1ND63QJ3j9TT0mgp_5fpmPA82FhMT_-mPU25PEFY')
-    return_val = RecordingReadyNotifierService.execute(recording.id)
+    return_val = described_class.execute(recording.id)
 
     expect(return_val).to be false
   end
@@ -44,9 +48,9 @@ RSpec.describe RecordingReadyNotifierService, type: :service do
       stub_request(:post, url)
         .to_return(status: 200, body: '', headers: {})
 
-      expect(JWT).to receive(:encode).and_return(JWT.encode({ meeting_id: recording.meeting_id, record_id: recording.id }, tenant.secrets_array[0]))
+      expect(JWT).to receive(:encode).with({ meeting_id: recording.meeting_id, record_id: recording.record_id }, tenant.secrets_array[0])
 
-      RecordingReadyNotifierService.execute(recording.id)
+      described_class.execute(recording.id)
     end
   end
 end


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

fixes #971 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During the recording ready callback, the meetingID and recordingID should be signed using either the LOADBALANCER_SECRET or the secret for the given tenant. 

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
