### PR TITLE
Fix bug causing getRecordings not to return all the metadata

### DIFF
--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -334,7 +334,11 @@ class BigBlueButtonApiController < ApplicationController
     query = Recording.includes(playback_formats: [:thumbnails], metadata: []).references(:metadata)
 
     # Filter recordings for current tenant
-    query = query.where(metadata: { key: 'tenant-id', value: @tenant.id }) if @tenant.present?
+    if @tenant.present?
+      tenant_recs = Metadatum.where(key: 'tenant-id', value: @tenant.id).pluck(:recording_id)
+      query = query.where(id: tenant_recs)
+      #     query = query.where(metadata: { key: 'tenant-id', value: @tenant.id })
+    end
 
     query = if params[:state].present?
               states = params[:state].split(',')

--- a/spec/requests/bigbluebutton_api_controller_spec.rb
+++ b/spec/requests/bigbluebutton_api_controller_spec.rb
@@ -1802,6 +1802,21 @@ RSpec.describe BigBlueButtonApiController, redis: true do
         expect(xml_response.at_xpath("//response/returncode").text).to eq("SUCCESS")
         expect(xml_response.xpath("//response/recordings/recording").count).to eq(1)
       end
+
+      it 'returns all metadata' do
+        r1 = create(:recording, state: 'published')
+        create(:metadatum, recording: r1, key: "tenant-id", value: tenant.id)
+        create(:metadatum, recording: r1, key: "test-key", value: 'test-value')
+
+        params = encode_bbb_params("getRecordings", { recordID: r1.record_id })
+
+        get bigbluebutton_api_get_recordings_url, params: params
+
+        expect(response).to have_http_status(:success)
+        xml_response = Nokogiri::XML(response.body)
+        expect(xml_response.xpath("//response/recordings/recording/metadata/tenant-id")).to be_present
+        expect(xml_response.xpath("//response/recordings/recording/metadata/test-key")).to be_present
+      end
     end
   end
 


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

fixes #987 

## Description
<!--- Describe your changes in detail -->
Because of how the  query was structured, only the `tenant-id` metadata was returned, while the other metadata for the same recording was filtered out. 

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
