### PR TITLE
fix: add protocol guard to servers:add rake task

### DIFF
--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -26,6 +26,12 @@ namespace :servers do
       puts('Error: Please input at least a URL and a secret!')
       exit(1)
     end
+
+    unless args.url.start_with?('http://', 'https://')
+      puts('Error: Server URL must start with http:// or https://')
+      exit(1)
+    end
+
     tmp_load_multiplier = 1.0
     unless args.load_multiplier.nil?
       tmp_load_multiplier = args.load_multiplier.to_d


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a guard in `rake servers:add` to return an error if the user does not include the protocol (http:// or https://) in the server url.

Not having the protocol in the url would cause an error when using Ruby `URI` method, for example when using `rake status`.

Fixes #996 and #997 

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
(try to) Add a server without the protocol in the url and it should return an error.
`rake servers:add['myhost.bbb.com','k2934k2934k9234']`

