### PR TITLE
Example fix for panic call/task when MT is enabled

### DIFF
--- a/app/controllers/api/servers_controller.rb
+++ b/app/controllers/api/servers_controller.rb
@@ -136,7 +136,11 @@ module Api
     def panic_server
       begin
         keep_state = (server_panic_params[:keep_state].presence || false)
-        meetings = Meeting.all.select { |m| m.server_id == @server.id }
+        if tenant_id.present?
+          meetings = Meeting.all(@tenant_id).select { |m| m.server_id == @server.id }
+        else
+          meetings = Meeting.all.select { |m| m.server_id == @server.id }
+        end
         meetings.each do |meeting|
           moderator_pw = meeting.try(:moderator_pw)
           meeting.destroy!


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

## Description
<!--- Describe your changes in detail -->

This is an example of a fix for the panicServer API call and panic rake tasks when Multitenancy is enabled. Previously, the list of meetings used in these would be empty, leaving all meetings on the panicked server running and not cleared from the list of meetings.

Fixes https://github.com/blindsidenetworks/scalelite/issues/1010

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

Enable MT, create meeting, panic the server via rake task. Observe that the meeting will be ended and cleared, unlike without the fix.

The API call panicServer is UNTESTED, because I didn't get it to work immediately with API mate and do not have the time to to deal with it right now.

## Notes

Actually, I'd propose to change the behavior of Meeting.all() such that it lists all meetings of all tenants, if tenant id is not passed, instead of only meetings without tenant association. In calls where only a certain tenant is concerned, the tenant id argument is naturally to be passed anyway, leading to the desired behavior.

See https://github.com/blindsidenetworks/scalelite/pull/1012