### PR TITLE
Let Meeting.all return all meetings if tenant_id argument is not passed

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -277,13 +277,8 @@ class Meeting < ApplicationRedisRecord
         hash = redis.hgetall(key(id))
         next if hash.blank?
 
-        if tenant_id.present?
-          # Only fetch meetings for particular Tenant
-          next if tenant_id != hash['tenant_id']
-        elsif hash['tenant_id'].present?
-          next
-        end
-        # Only fetch meetings without Tenant
+        # If tenant_id given, only fetch meetings for particular Tenant
+        next if tenant_id.present? && hash['tenant_id'] != tenant_id
 
         hash[:id] = id
         meetings << new.init_with_attributes(hash)


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->
Let Meeting.all return all meetings, regardless of tenant association, if tenant_id argument is not passed.


## Description
<!--- Describe your changes in detail -->
Previously, with Multitenancy enabled, Meeting.all would return only meetings without tenant association if the optional argument tenant_id was not passed. This leads to numerous bugs in the code, because the tenant_id argument is not passed in many cases. An example would be https://github.com/blindsidenetworks/scalelite/issues/1010 .

I propose to let Meeting.all return all meetings, regardless of tenant association, when it is called without tenant_id. In any case where only a certain tenant is considered, the tenant_id would have to be passed anyway. This fixes the issues with meetings remaining associated after panicking/disabling servers with Multitenancy enabled.

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
Test all the uses of Meeting.all:

https://github.com/search?q=repo%3Ablindsidenetworks%2Fscalelite%20Meeting.all&type=code

## Fixed Issues
At least:
https://github.com/blindsidenetworks/scalelite/issues/993
https://github.com/blindsidenetworks/scalelite/issues/1010