### PR TITLE
Recoding files size and raw size info

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,3 +255,9 @@ DEPENDENCIES
   tabulo (~> 2.8.1)
   tzinfo-data
   webmock
+
+RUBY VERSION
+   ruby 2.7.7p221
+
+BUNDLED WITH
+   2.4.12

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -43,6 +43,10 @@ class Recording < ApplicationRecord
     recording_params[:participants] = participants.to_i if participants.present?
     state = recording_xml.at_xpath('state')&.text
     recording_params[:state] = state if state.present?
+    rawSize = recording_xml.at_xpath('raw_size')&.text
+    recording_params[:rawSize] = rawSize.to_i if rawSize.present?
+    size = recording_xml.at_xpath('size')&.text
+    recording_params[:size] = size.to_i if size.present?
     # Workaround screenshare state bug
     recording_params[:state] = 'published' if recording_params[:state] == 'available'
     start_time = recording_xml.at_xpath('start_time')&.text

--- a/app/views/bigbluebutton_api/get_recordings.xml.builder
+++ b/app/views/bigbluebutton_api/get_recordings.xml.builder
@@ -15,6 +15,8 @@ xml.response do
         xml.startTime((recording.starttime.to_r * 1000).to_i)
         xml.endTime((recording.endtime.to_r * 1000).to_i)
         xml.participants recording.participants unless recording.participants.nil?
+        xml.rawSize recording.rawSize unless recording.rawSize.nil?
+        xml.size recording.size unless recording.size.nil?
         xml.metadata do
           recording.metadata.each do |metadatum|
             if metadatum.value.blank?


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Recording API in BBB over scalelite is not fully implemented. We cannot get how much space the recordings take up on the disk. With this PR will be able to get those information.
<img width="805" alt="Ekran Resmi 2023-12-24 16 34 39" src="https://github.com/blindsidenetworks/scalelite/assets/1829975/b62e748c-1678-4fe3-9b93-396f0db57cbc">

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
1. Use api mate and test recorded meeting. You should see like that
![image](https://github.com/blindsidenetworks/scalelite/assets/1829975/a86b0c8f-889f-4167-ba55-c8f5441dfac2)


## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
