### PR TITLE
Support for tagged servers (ready for review)

### DIFF
--- a/app/controllers/api/servers_controller.rb
+++ b/app/controllers/api/servers_controller.rb
@@ -73,7 +73,7 @@ module Api
     #     "url": String,                 # Required: URL of the BigBlueButton server
     #     "secret": String,              # Required: Secret key of the BigBlueButton server
     #     "load_multiplier": Float       # Optional: A non-zero number, defaults to 1.0 if not provided or zero
-    #     "tag": String                  # Optional: A special-purpose tag for the server (empty String to set nil)
+    #     "tag": String                  # Optional: A special-purpose tag for the server (empty String to not set it)
     #   }
     # }
     def add_server
@@ -82,10 +82,9 @@ module Api
       else
         tmp_load_multiplier = server_create_params[:load_multiplier].presence&.to_d || 1.0
         tmp_load_multiplier = 1.0 if tmp_load_multiplier.zero?
-        tmp_tag = server_create_params[:tag].presence
 
         server = Server.create!(url: server_create_params[:url], secret: server_create_params[:secret],
-                                load_multiplier: tmp_load_multiplier, tag: tmp_tag)
+                                load_multiplier: tmp_load_multiplier, tag: server_create_params[:tag].presence)
         render json: server_to_json(server), status: :created
       end
     end

--- a/app/controllers/api/servers_controller.rb
+++ b/app/controllers/api/servers_controller.rb
@@ -18,6 +18,7 @@ module Api
     #     "id": String,
     #     "url": String,
     #     "secret": String,
+    #     "tag": String,
     #     "state": String,
     #     "load": String,
     #     "load_multiplier": String,
@@ -49,6 +50,7 @@ module Api
     #     "id": String,
     #     "url": String,
     #     "secret": String,
+    #     "tag": String,
     #     "state": String,
     #     "load": String,
     #     "load_multiplier": String,
@@ -71,6 +73,7 @@ module Api
     #     "url": String,                 # Required: URL of the BigBlueButton server
     #     "secret": String,              # Required: Secret key of the BigBlueButton server
     #     "load_multiplier": Float       # Optional: A non-zero number, defaults to 1.0 if not provided or zero
+    #     "tag": String                  # Optional: A special-purpose tag for the server (empty String to set nil)
     #   }
     # }
     def add_server
@@ -79,8 +82,10 @@ module Api
       else
         tmp_load_multiplier = server_create_params[:load_multiplier].presence&.to_d || 1.0
         tmp_load_multiplier = 1.0 if tmp_load_multiplier.zero?
+        tmp_tag = server_create_params[:tag].presence
 
-        server = Server.create!(url: server_create_params[:url], secret: server_create_params[:secret], load_multiplier: tmp_load_multiplier)
+        server = Server.create!(url: server_create_params[:url], secret: server_create_params[:secret],
+                                load_multiplier: tmp_load_multiplier, tag: tmp_tag)
         render json: server_to_json(server), status: :created
       end
     end
@@ -95,6 +100,7 @@ module Api
     #     "state": String,         # Optional: 'enable', 'cordon', or 'disable'
     #     "load_multiplier": Float # Optional: A non-zero number
     #     "secret": String         # Optional: Secret key of the BigBlueButton server
+    #     "tag": String            # Optional: A special-purpose tag for the server, empty string to remove the tag
     #   }
     # }
     def update_server
@@ -166,6 +172,7 @@ module Api
         id: server.id,
         url: server.url,
         secret: server.secret,
+        tag: server.tag.nil? ? '' : server.tag,
         state: server.state.presence || (server.enabled ? 'enabled' : 'disabled'),
         load: server.load.presence || 'unavailable',
         load_multiplier: server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d,
@@ -174,11 +181,11 @@ module Api
     end
 
     def server_create_params
-      params.require(:server).permit(:url, :secret, :load_multiplier)
+      params.require(:server).permit(:url, :secret, :load_multiplier, :tag)
     end
 
     def server_update_params
-      params.require(:server).permit(:state, :load_multiplier, :secret)
+      params.require(:server).permit(:state, :load_multiplier, :secret, :tag)
     end
 
     def server_panic_params

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -188,7 +188,11 @@ class BigBlueButtonApiController < ApplicationController
     duration = params[:duration].to_i
 
     params[:'meta_tenant-id'] = @tenant.id if @tenant.present?
-    params[:'meta_server-tag'] = server.tag if server.tag.present?
+    if server.tag.present?
+      params[:'meta_server-tag'] = server.tag
+    else
+      params.delete(:'meta_server-tag')
+    end
 
     # Set/Overite duration if MAX_MEETING_DURATION is set and it's greater than params[:duration] (if passed)
     if !Rails.configuration.x.max_meeting_duration.zero? &&

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -188,6 +188,7 @@ class BigBlueButtonApiController < ApplicationController
     duration = params[:duration].to_i
 
     params[:'meta_tenant-id'] = @tenant.id if @tenant.present?
+    params[:'meta_server-tag'] = server.tag if server.tag.present?
 
     # Set/Overite duration if MAX_MEETING_DURATION is set and it's greater than params[:duration] (if passed)
     if !Rails.configuration.x.max_meeting_duration.zero? &&

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -160,7 +160,7 @@ class BigBlueButtonApiController < ApplicationController
     params.require(:meetingID)
 
     begin
-      server = Server.find_available
+      server = Server.find_available(params[:'meta_server-tag'])
     rescue ApplicationRedisRecord::RecordNotFound
       raise InternalError, 'Could not find any available servers.'
     end

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -161,8 +161,8 @@ class BigBlueButtonApiController < ApplicationController
 
     begin
       server = Server.find_available(params[:'meta_server-tag'])
-    rescue ApplicationRedisRecord::RecordNotFound
-      raise InternalError, 'Could not find any available servers.'
+    rescue ApplicationRedisRecord::RecordNotFound => e
+      raise InternalError, e.message
     end
 
     # Create meeting in database

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -291,13 +291,13 @@ class Server < ApplicationRedisRecord
 
     # Find available&matching server with the lowest load
     with_connection do |redis|
-      ids = redis.zrange('server_load', 0, 0, with_scores: false)
-      if ids.none? { |myid| redis.hget(key(myid), 'tag') == tag }
+      ids = redis.zrange('server_load', 0, -1, with_scores: false)
+      if !tag.nil? && ids.none? { |myid| redis.hget(key(myid), 'tag') == tag }
         raise RecordNotFound.new("Couldn't find available Server", name, nil) if tag_required
         tag = nil # fall back to servers without tag
       end
       id, load, hash = 5.times do
-        ids_loads = redis.zrange('server_load', 0, 0, with_scores: true)
+        ids_loads = redis.zrange('server_load', 0, -1, with_scores: true)
         raise RecordNotFound.new("Couldn't find available Server", name, nil) if ids_loads.blank?
 
         id, load = ids_loads.find { |myid, _| redis.hget(key(myid), 'tag') == tag }

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -94,7 +94,9 @@ class Server < ApplicationRedisRecord
         result = redis.multi do |pipeline|
           pipeline.hset(server_key, 'url', url) if url_changed?
           pipeline.hset(server_key, 'secret', secret) if secret_changed?
-          pipeline.hset(server_key, 'tag', tag) if tag_changed?
+          if tag_changed?
+            tag.nil? ? pipeline.hdel(server_key, 'tag') : pipeline.hset(server_key, 'tag', tag)
+          end
           pipeline.hset(server_key, 'online', online ? 'true' : 'false') if online_changed?
           pipeline.hset(server_key, 'load_multiplier', load_multiplier) if load_multiplier_changed?
           pipeline.hset(server_key, 'state', state) if state_changed?

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -293,18 +293,18 @@ class Server < ApplicationRedisRecord
     with_connection do |redis|
       ids = redis.zrange('server_load', 0, -1, with_scores: false)
       if !tag.nil? && ids.none? { |myid| redis.hget(key(myid), 'tag') == tag }
-        raise RecordNotFound.new("Couldn't find available Server", name, nil) if tag_required
+        raise RecordNotFound.new("Could not find any available servers with tag=#{tag}.", name, nil) if tag_required
         tag = nil # fall back to servers without tag
       end
       id, load, hash = 5.times do
         ids_loads = redis.zrange('server_load', 0, -1, with_scores: true)
-        raise RecordNotFound.new("Couldn't find available Server", name, nil) if ids_loads.blank?
+        raise RecordNotFound.new("Could not find any available servers.", name, nil) if ids_loads.blank?
 
         id, load = ids_loads.find { |myid, _| redis.hget(key(myid), 'tag') == tag }
         hash = redis.hgetall(key(id))
         break id, load, hash if hash.present?
       end
-      raise RecordNotFound.new("Couldn't find available Server", name, id) if hash.blank?
+      raise RecordNotFound.new("Could not find any available servers.", name, id) if hash.blank?
 
       hash['id'] = id
       if hash['state'].present?

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -95,7 +95,7 @@ class Server < ApplicationRedisRecord
           pipeline.hset(server_key, 'url', url) if url_changed?
           pipeline.hset(server_key, 'secret', secret) if secret_changed?
           if tag_changed?
-            tag.nil? ? pipeline.hdel(server_key, 'tag') : pipeline.hset(server_key, 'tag', tag)
+            tag.present? ? pipeline.hset(server_key, 'tag', tag) : pipeline.hdel(server_key, 'tag')
           end
           pipeline.hset(server_key, 'online', online ? 'true' : 'false') if online_changed?
           pipeline.hset(server_key, 'load_multiplier', load_multiplier) if load_multiplier_changed?
@@ -284,10 +284,10 @@ class Server < ApplicationRedisRecord
   # Find the server with the lowest load (for creating a new meeting)
   def self.find_available(tag_arg = nil)
     # Check if tag is required
-    tag = tag_arg
+    tag = tag_arg.presence
     tag_required = false
     if !tag.nil? && tag[-1] == '!'
-        tag = tag[0..-2] # always returns String, if tag is String
+        tag = tag[0..-2].presence # always returns String, if tag is String
         tag_required = true
     end
 

--- a/app/services/server_update_service.rb
+++ b/app/services/server_update_service.rb
@@ -13,6 +13,8 @@ class ServerUpdateService
 
     update_secret if @params[:secret].present?
 
+    update_tag unless @params[:tag].nil?
+
     @server.save!
   end
 
@@ -42,5 +44,9 @@ class ServerUpdateService
 
   def update_secret
     @server.secret = @params[:secret]
+  end
+
+  def update_tag
+    @server.tag = @params[:tag].presence
   end
 end

--- a/docs/api-README.md
+++ b/docs/api-README.md
@@ -22,6 +22,7 @@ n/a
    "id": String,
    "url": String,
    "secret": String,
+   "tag": String,
    "state": String,
    "load": String,
    "load_multiplier": String,
@@ -56,6 +57,7 @@ Returns the data associated with a single server
   "id": String,
   "url": String,
   "secret": String,
+  "tag": String,
   "state": String,
   "load": String,
   "load_multiplier": String,
@@ -83,7 +85,8 @@ Adds a new server
   "server": {
     "url": String,                 # Required: URL of the BigBlueButton server
     "secret": String,              # Required: Secret key of the BigBlueButton server
-    "load_multiplier": Float       # Optional: A non-zero number, defaults to 1.0 if not provided or zero
+    "load_multiplier": Float,      # Optional: A non-zero number, defaults to 1.0 if not provided or zero
+    "tag": String                  # Optional: A special-purpose tag for the server (empty string to not set it)
   }
 }
 ```
@@ -94,6 +97,7 @@ Adds a new server
   "id": String,
   "url": String,
   "secret": String,
+  "tag": String,
   "state": String,
   "load": String,
   "load_multiplier": String,
@@ -122,7 +126,8 @@ Updates a server
   "server": {
     "state": String,         # Optional: 'enable', 'cordon', or 'disable'
     "load_multiplier": Float # Optional: A non-zero number
-    "secret": String         # Optional: Secret key of the BigBlueButton server
+    "secret": String,        # Optional: Secret key of the BigBlueButton server
+    "tag": String            # Optional: A special-purpose tag for the server (empty string to remove the tag)
   }
 }
 ```
@@ -133,6 +138,7 @@ Updates a server
   "id": String,
   "url": String,
   "secret": String,
+  "tag": String,
   "state": String,
   "load": String,
   "load_multiplier": String,

--- a/docs/rake-README.md
+++ b/docs/rake-README.md
@@ -131,13 +131,15 @@ Particular information to note:
 ### Add a server
 
 ```sh
-./bin/rake servers:add[url,secret,loadMultiplier]
+./bin/rake servers:add[url,secret,loadMultiplier,tag]
 ```
 
 The `url` value is the complete URL to the BigBlueButton API endpoint of the server. The `/api` on the end is required.
 You can find the BigBlueButton server's URL and Secret by running `bbb-conf --secret` on the BigBlueButton server.
 
 The `loadMultiplier` can be used to give individual servers a higher or lower priority over other servers. A higher loadMultiplier should be placed on the weaker servers. If not passed, it defaults to a value of `1`.
+
+The `tag` can be optionally passed to assign a special-purpose tag to the server. The tag can then be referenced via a meta-parameter in the create call, to place meetings only on servers with the corresponding tag.
 
 This command will print out the ID of the newly created server, and `OK` if it was successful.
 Note that servers are added in the disabled state; see "Enable a server" below to enable it.
@@ -156,12 +158,15 @@ You should either wait for all meetings to end, or run the "Panic" function firs
 ### Update a server
 
 ```sh
-./bin/rake servers:update[id,secret,loadMultiplier]
+./bin/rake servers:update[id,secret,loadMultiplier,tag]
 ```
 
 Updates the secret and load_multiplier for a BigBlueButton server.
 
 The `loadMultiplier` can be used to give individual servers a higher or lower priority over other servers. A higher loadMultiplier should be placed on the weaker servers.
+
+The `tag` can be optionally passed to assign a special-purpose tag to the server. The tag can then be referenced via a meta-parameter in the create call, to place meetings only on servers with the corresponding tag.
+Call the task with empty tag argument as in `servers:update[id,secret,loadMultiplier,]` to untag the server.
 
 After changing the server needs to be polled at least once to see the new load.
 
@@ -222,6 +227,16 @@ Sets the load_multiplier for a BigBlueButton server.
 The `loadMultiplier` can be used to give individual servers a higher or lower priority over other servers. A higher loadMultiplier should be placed on the weaker servers.
 
 After changing the server needs to be polled at least once to see the new load.
+
+### Tag a server
+
+```sh
+./bin/rake servers:tag[id,tag]
+```
+
+Adds or removes the tag for a BigBlueButton server.
+
+The `tag` argument is used to assign a special-purpose tag to the server. The tag can then be referenced via a meta-parameter in the create call, to place meetings only on servers with the corresponding tag. Call the task with empty tag argument as in `servers:tag[id,]` to untag the server.
 
 ### Poll all servers
 
@@ -300,6 +315,7 @@ servers:
         url: <string>            # default: "https://<server-id>/bigbluebutton/api"
         enabled: <bool>          # default: true
         load_multiplier: <float> # default: 1.0, must be greater than 0
+        tag: <string>            # default: ''
 
     # Example for a simple server with default values
     bbb1.example.com:
@@ -349,9 +365,9 @@ by `servers:sync`.
 This will print a table displaying a list of all servers and some basic statistics that can be used for monitoring the overall status of the deployment
 
 ```
-     HOSTNAME        STATE   STATUS  MEETINGS  USERS  LARGEST MEETING  VIDEOS
- bbb1.example.com  enabled   online        12     25                7      15
- bbb2.example.com  enabled   online         4     14                4       5
+     HOSTNAME        STATE   STATUS  MEETINGS  USERS  LARGEST MEETING  VIDEOS  LOAD   TAG
+ bbb1.example.com  enabled   online        12     25                7      15  25.0
+ bbb2.example.com  enabled   online         4     14                4       5  14.0   test
 ```
 
 ### Manage Meetings

--- a/docs/tags-README.md
+++ b/docs/tags-README.md
@@ -1,0 +1,22 @@
+# Tagged Servers
+
+## Description
+
+This feature allows to provide users the choice of specially configured servers (e.g. optimized for very large conferences or running newer BBB versions), without requiring a dedicated Loadbalancer + Frontend infrastructures. It works by first assigning so-called tags to certain servers and then referencing the tag via a meta-parameter in the create API call, to request placing the meeting on a server with corresponding tag. Because the create call is made by the BBB frontend, the feature needs to be supported by the frontend.
+
+## How to tag servers in Scalelite
+
+When adding a server in Scalelite, you can optionally specify a non-empty string as "tag" for the server. Per default, it is nil.
+
+This works for all supported ways of adding servers: Per `rake servers:add` task, per `addServer` API call or per `rake servers:sync` from YAML file. The same is true for the `rake servers:update` task and `updateServer` call. For more details, see `api-README.md` and `rake-README.md`.
+
+## Create call with server-tag metaparameter
+
+A create API call with a meta feature is supposed to work as follows:
+
+1) When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag string as parameter. If passed, it will be handled as follows:
+2) If the last character of meta_server-tag is not a '!', the tag will will be intepreted as *optional*. The meeting will be created on the lowest load server with the corresponding tag, if any is available, or on the lowest load untagged (i.e. tag == nil) server otherwise.
+3) If the last character of meta_server-tag is a '!', this character will be stripped and the remaining tag will be interpreted as *required*. The meeting will be created on the lowest load server with the corresponding tag or fail to be created (with specific error message), if no matching server is available.
+
+NOTE: Create calls without or with ''/'!' as meta_server-tag will only match untagged servers. So, for a frontend unaware of the feature, SL will behave as previously if a pool of untagged ("default") servers is maintained. It is recommended to always add your default servers as untagged servers.
+

--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -3,7 +3,7 @@
 # Tools to synchronize cluster state with a list of servers. Used by the
 # servers:sync an servers:yaml tasks.
 class ServerSync
-  SERVER_PARAMS = %w[url secret enabled load_multiplier].freeze
+  SERVER_PARAMS = %w[url secret enabled load_multiplier tag].freeze
   PARAMS_IGNORE = %w[load state online].freeze
   SYNC_MODES = %w[keep cordon force].freeze
 
@@ -29,8 +29,8 @@ class ServerSync
   # Synchronizes cluster state with a server list. The servers parameter should
   # be a hash mapping server IDs to parameters. The +secret+ parameter is
   # required, the API +url+ is auto-derived from the server id if it looks like
-  # a hostname, +enabled+ is true by defalt and +load_multiplier+ is +1.0+ by
-  # default.
+  # a hostname, +enabled+ is true by defalt, +load_multiplier+ is +1.0+ by
+  # default and +tag+ is +nil+ by default.
   # The +mode+ decides what happens to undesired servers. Valid values are
   # +keep+, +cordon+ (default) and +force+. The last option will end all
   # meetings before the server is removed.
@@ -51,6 +51,7 @@ class ServerSync
       params['url'] = "https://#{id}/bigbluebutton/api" if params['url'].nil?
       params['enabled'] = params['enabled'].nil? || !!params['enabled']
       params['load_multiplier'] = 1.0 if params['load_multiplier'].nil?
+      params['tag'] = params['tag'].presence
       bad_params = params.keys - SERVER_PARAMS - PARAMS_IGNORE
 
       raise(SyncError, "Server id=#{id} contains invalid characters") unless /^[a-zA-Z0-9_.-]+$/.match?(id)
@@ -77,7 +78,8 @@ class ServerSync
             id: id,
             url: params['url'],
             secret: params['secret'],
-            load_multiplier: params['load_multiplier']
+            load_multiplier: params['load_multiplier'],
+            tag: params['tag']
           )
         end
         logger.info("[#{id}] Server created")
@@ -95,6 +97,10 @@ class ServerSync
       unless server.load_multiplier.to_d == params['load_multiplier']
         server.load_multiplier = params['load_multiplier']
         logger.info("[#{id}] Server updated: load_multiplier=#{params['load_multiplier']}")
+      end
+      unless server.tag == params['tag']
+        server.tag = params['tag']
+        logger.info("[#{id}] Server updated: tag=#{params['tag']}")
       end
 
       if params['enabled'] && !server.enabled?
@@ -174,6 +180,7 @@ class ServerSync
         url: server.url,
         secret: server.secret,
         load_multiplier: server.load_multiplier.to_f || 1.0,
+        tag: server.tag.nil? ? '' : server.tag,
         enabled: server.enabled,
       }
       if verbose

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -177,6 +177,17 @@ namespace :servers do
     exit(1)
   end
 
+  desc 'Set the tag of a BigBlueButton server'
+  task :tag, [:id, :tag] => :environment do |_t, args|
+    server = Server.find(args.id)
+    server.tag = args.tag.presence
+    server.save!
+    puts('OK')
+  rescue ApplicationRedisRecord::RecordNotFound
+    puts("ERROR: No server found with id: #{args.id}")
+    exit(1)
+  end
+
   desc 'Adds multiple BigBlueButton servers defined in a YAML file passed as an argument'
   task :addAll, [:path] => :environment do |_t, args|
     servers = YAML.load_file(args.path)['servers']

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -15,7 +15,7 @@ task servers: :environment do
     end
     puts("\tload: #{server.load.presence || 'unavailable'}")
     puts("\tload multiplier: #{server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d}")
-    puts("\ttag: #{server.tag}")
+    puts("\ttag: #{server.tag.nil ? '' : server.tag}")
     puts("\t#{server.online ? 'online' : 'offline'}")
   end
 end
@@ -41,7 +41,7 @@ namespace :servers do
         tmp_load_multiplier = 1.0
       end
     end
-    server = Server.create!(url: args.url, secret: args.secret, load_multiplier: tmp_load_multiplier, tag: args.tag)
+    server = Server.create!(url: args.url, secret: args.secret, load_multiplier: tmp_load_multiplier, tag: args.tag.presence)
     puts('OK')
     puts("id: #{server.id}")
   end
@@ -59,7 +59,7 @@ namespace :servers do
       end
     end
     server.load_multiplier = tmp_load_multiplier
-    server.tag = args.tag unless args.tag.nil?
+    server.tag = args.tag.presence unless args.tag.nil?
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -15,7 +15,7 @@ task servers: :environment do
     end
     puts("\tload: #{server.load.presence || 'unavailable'}")
     puts("\tload multiplier: #{server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d}")
-    puts("\ttag: #{server.tag.nil ? '' : server.tag}")
+    puts("\ttag: #{server.tag.nil? ? '' : server.tag}")
     puts("\t#{server.online ? 'online' : 'offline'}")
   end
 end

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -15,13 +15,14 @@ task servers: :environment do
     end
     puts("\tload: #{server.load.presence || 'unavailable'}")
     puts("\tload multiplier: #{server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d}")
+    puts("\ttag: #{server.tag}")
     puts("\t#{server.online ? 'online' : 'offline'}")
   end
 end
 
 namespace :servers do
   desc 'Add a new BigBlueButton server (it will be added disabled)'
-  task :add, [:url, :secret, :load_multiplier] => :environment do |_t, args|
+  task :add, [:url, :secret, :load_multiplier, :tag] => :environment do |_t, args|
     if args.url.nil? || args.secret.nil?
       puts('Error: Please input at least a URL and a secret!')
       exit(1)
@@ -40,13 +41,13 @@ namespace :servers do
         tmp_load_multiplier = 1.0
       end
     end
-    server = Server.create!(url: args.url, secret: args.secret, load_multiplier: tmp_load_multiplier)
+    server = Server.create!(url: args.url, secret: args.secret, load_multiplier: tmp_load_multiplier, tag: args.tag)
     puts('OK')
     puts("id: #{server.id}")
   end
 
   desc 'Update a BigBlueButton server'
-  task :update, [:id, :secret, :load_multiplier] => :environment do |_t, args|
+  task :update, [:id, :secret, :load_multiplier, :tag] => :environment do |_t, args|
     server = Server.find(args.id)
     server.secret = args.secret unless args.secret.nil?
     tmp_load_multiplier = server.load_multiplier
@@ -58,6 +59,7 @@ namespace :servers do
       end
     end
     server.load_multiplier = tmp_load_multiplier
+    server.tag = args.tag unless args.tag.nil?
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -7,7 +7,7 @@ task status: :environment do
   include ApiHelper
 
   servers_info = []
-  ServerInfo = Struct.new(:hostname, :state, :status, :meetings, :users, :largest, :videos, :load)
+  ServerInfo = Struct.new(:hostname, :state, :status, :meetings, :users, :largest, :videos, :load, :tag)
 
   Server.all.each do |server|
     state = server.state
@@ -15,7 +15,7 @@ task status: :environment do
     state = server.state.present? ? status_with_state(state) : status_without_state(enabled)
 
     info = ServerInfo.new(URI.parse(server.url).host, state, server.online ? 'online' : 'offline', server.meetings, server.users,
-server.largest_meeting, server.videos, server.load)
+server.largest_meeting, server.videos, server.load, server.tag)
 
     # Convert to openstruct to allow dot syntax usage
     servers_info.push(info)
@@ -33,6 +33,7 @@ server.largest_meeting, server.videos, server.load)
     t.add_column('LARGEST MEETING', &:largest)
     t.add_column('VIDEOS', &:videos)
     t.add_column('LOAD', &:load)
+    t.add_column('TAG', &:tag)
   end
 
   puts table.pack

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -243,7 +243,7 @@ class ServerTest < ActiveSupport::TestCase
     end
   end
 
-  test 'Server find_available without tag returns untagged server with lowest load' do
+  test 'Server find_available without or with empty tag returns untagged server with lowest load' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           tag: 'test-tag', enabled: 'true')
@@ -270,6 +270,12 @@ class ServerTest < ActiveSupport::TestCase
     assert(server.enabled)
     assert_nil(server.state)
     assert_equal(2, server.load)
+
+    server = Server.find_available('')
+    assert_equal('test-3', server.id)
+
+    server = Server.find_available('!')
+    assert_equal('test-3', server.id)
   end
 
   test 'Server find_available with optional tag returns matching tagged server with lowest load' do

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -130,6 +130,12 @@ class ServerTest < ActiveSupport::TestCase
     end
   end
 
+  test 'Server find_available with any tag and no available servers' do
+    assert_raises(ApplicationRedisRecord::RecordNotFound) do
+      Server.find_available('test-tag')
+    end
+  end
+
   test 'Server find_available with missing server hash' do
     # This is mostly a failsafe check
     RedisStore.with_connection do |redis|
@@ -234,6 +240,151 @@ class ServerTest < ActiveSupport::TestCase
 
     assert_raises(ApplicationRedisRecord::RecordNotFound) do
       Server.find_available
+    end
+  end
+
+  test 'Server find_available without tag returns untagged server with lowest load' do
+    RedisStore.with_connection do |redis|
+      redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
+                                          tag: 'test-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
+      redis.zadd('server_load', 1, 'test-1')
+      redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
+      redis.zadd('server_load', 3, 'test-2')
+      redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-3')
+      redis.sadd?('server_enabled', 'test-3')
+      redis.zadd('server_load', 2, 'test-3')
+    end
+
+    server = Server.find_available
+    assert_equal('test-3', server.id)
+    assert_equal('https://test-3.example.com/bigbluebutton/api', server.url)
+    assert_equal('test-3-secret', server.secret)
+    assert_nil(server.tag)
+    assert(server.enabled)
+    assert_nil(server.state)
+    assert_equal(2, server.load)
+  end
+
+  test 'Server find_available with optional tag returns matching tagged server with lowest load' do
+    RedisStore.with_connection do |redis|
+      redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
+      redis.zadd('server_load', 1, 'test-1')
+      redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
+                                          tag: 'test-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
+      redis.zadd('server_load', 3, 'test-2')
+      redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
+                                          tag: 'test-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-3')
+      redis.sadd?('server_enabled', 'test-3')
+      redis.zadd('server_load', 2, 'test-3')
+      redis.mapped_hmset('server:test-4', url: 'https://test-4.example.com/bigbluebutton/api', secret: 'test-4-secret',
+                                          tag: 'wrong-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-4')
+      redis.sadd?('server_enabled', 'test-4')
+      redis.zadd('server_load', 1, 'test-4')
+    end
+
+    server = Server.find_available('test-tag')
+    assert_equal('test-3', server.id)
+    assert_equal('https://test-3.example.com/bigbluebutton/api', server.url)
+    assert_equal('test-3-secret', server.secret)
+    assert_equal('test-tag', server.tag)
+    assert(server.enabled)
+    assert_nil(server.state)
+    assert_equal(2, server.load)
+  end
+
+  test 'Server find_available with required tag returns matching tagged server with lowest load' do
+    RedisStore.with_connection do |redis|
+      redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
+      redis.zadd('server_load', 1, 'test-1')
+      redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
+                                          tag: 'test-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
+      redis.zadd('server_load', 3, 'test-2')
+      redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
+                                          tag: 'test-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-3')
+      redis.sadd?('server_enabled', 'test-3')
+      redis.zadd('server_load', 2, 'test-3')
+      redis.mapped_hmset('server:test-4', url: 'https://test-4.example.com/bigbluebutton/api', secret: 'test-4-secret',
+                                          tag: 'wrong-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-4')
+      redis.sadd?('server_enabled', 'test-4')
+      redis.zadd('server_load', 1, 'test-4')
+    end
+
+    server = Server.find_available('test-tag!')
+    assert_equal('test-3', server.id)
+    assert_equal('https://test-3.example.com/bigbluebutton/api', server.url)
+    assert_equal('test-3-secret', server.secret)
+    assert_equal('test-tag', server.tag)
+    assert(server.enabled)
+    assert_nil(server.state)
+    assert_equal(2, server.load)
+  end
+
+  test 'Server find_available with optional tag returns untagged server with lowest load if no matching tagged server available' do
+    RedisStore.with_connection do |redis|
+      redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
+      redis.zadd('server_load', 3, 'test-1')
+      redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
+                                          tag: 'wrong-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
+      redis.zadd('server_load', 1, 'test-2')
+      redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-3')
+      redis.sadd?('server_enabled', 'test-3')
+      redis.zadd('server_load', 2, 'test-3')
+    end
+
+    server = Server.find_available('test-tag')
+    assert_equal('test-3', server.id)
+    assert_equal('https://test-3.example.com/bigbluebutton/api', server.url)
+    assert_equal('test-3-secret', server.secret)
+    assert_nil(server.tag)
+    assert(server.enabled)
+    assert_nil(server.state)
+    assert_equal(2, server.load)
+  end
+
+  test 'Server find_available with required tag raises error if no matching tagged server available' do
+    RedisStore.with_connection do |redis|
+      redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
+      redis.zadd('server_load', 2, 'test-1')
+      redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
+                                          tag: 'wrong-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
+      redis.zadd('server_load', 1, 'test-2')
+    end
+
+    assert_raises(ApplicationRedisRecord::RecordNotFound) do
+      Server.find_available('test-tag!')
     end
   end
 

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -278,7 +278,7 @@ class ServerTest < ActiveSupport::TestCase
     assert_equal('test-3', server.id)
   end
 
-  test 'Server find_available with optional tag returns matching tagged server with lowest load' do
+  test 'Server find_available with tag argument returns matching tagged server with lowest load' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           enabled: 'true')
@@ -310,40 +310,10 @@ class ServerTest < ActiveSupport::TestCase
     assert(server.enabled)
     assert_nil(server.state)
     assert_equal(2, server.load)
-  end
-
-  test 'Server find_available with required tag returns matching tagged server with lowest load' do
-    RedisStore.with_connection do |redis|
-      redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
-                                          enabled: 'true')
-      redis.sadd?('servers', 'test-1')
-      redis.sadd?('server_enabled', 'test-1')
-      redis.zadd('server_load', 1, 'test-1')
-      redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
-                                          tag: 'test-tag', enabled: 'true')
-      redis.sadd?('servers', 'test-2')
-      redis.sadd?('server_enabled', 'test-2')
-      redis.zadd('server_load', 3, 'test-2')
-      redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
-                                          tag: 'test-tag', enabled: 'true')
-      redis.sadd?('servers', 'test-3')
-      redis.sadd?('server_enabled', 'test-3')
-      redis.zadd('server_load', 2, 'test-3')
-      redis.mapped_hmset('server:test-4', url: 'https://test-4.example.com/bigbluebutton/api', secret: 'test-4-secret',
-                                          tag: 'wrong-tag', enabled: 'true')
-      redis.sadd?('servers', 'test-4')
-      redis.sadd?('server_enabled', 'test-4')
-      redis.zadd('server_load', 1, 'test-4')
-    end
 
     server = Server.find_available('test-tag!')
     assert_equal('test-3', server.id)
-    assert_equal('https://test-3.example.com/bigbluebutton/api', server.url)
-    assert_equal('test-3-secret', server.secret)
     assert_equal('test-tag', server.tag)
-    assert(server.enabled)
-    assert_nil(server.state)
-    assert_equal(2, server.load)
   end
 
   test 'Server find_available with optional tag returns untagged server with lowest load if no matching tagged server available' do
@@ -375,7 +345,7 @@ class ServerTest < ActiveSupport::TestCase
     assert_equal(2, server.load)
   end
 
-  test 'Server find_available with required tag raises error if no matching tagged server available' do
+  test 'Server find_available with required tag raises error with specific message if no matching tagged server available' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           enabled: 'true')
@@ -389,7 +359,7 @@ class ServerTest < ActiveSupport::TestCase
       redis.zadd('server_load', 1, 'test-2')
     end
 
-    assert_raises(ApplicationRedisRecord::RecordNotFound) do
+    assert_raises(ApplicationRedisRecord::RecordNotFound, "Could not find any available servers with tag=test-tag.") do
       Server.find_available('test-tag!')
     end
   end


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR implements a new feature called "Server Tags" or "Tagged Servers".

It is supposed to work as follows:

1. When adding a server in Scalelite, you can optionally specify a non-empty string as "tag" for the server. Per default, it is nil.
2. When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag string as parameter. If  passed, it will be handled as follows:
- If the last character of meta_server-tag is not a '!', the tag will will be intepreted as optional. The meeting will be created on the lowest load server with the corresponding tag, if any is available, or on the lowest load untagged (i.e. tag == nil) server otherwise.
- If the last character of meta_server-tag is a '!', this character will be stripped and the remaining tag will be interpreted as required. The meeting will be created on the lowest load server with the corresponding tag or fail to be created (with specific error message), if no matching server is available.
3. Create calls without or with ''/'!' as meta_server-tag will only match untagged servers. So, for a frontend unaware of the feature, SL will behave as previously if a pool of untagged ("default") servers is maintained. It is recommended to always add your default servers as untagged servers.

This feature allows to provide users the choice of specially configured servers (e.g. optimized for very large conferences) or newer, potentially less stable, BBB versions, without the need of using dedicated LB + Frontend infrastructures. It might be very useful for the transition to BBB 3.0, of which I know many admins are afraid due to the amount of changes in the BBB backend.

**Note:** Because in the current handling of the create call, Server.find_available will always be executed *before* checking for existing meetings, any error raised in that method will lead to the create call failing (even if the meeting does already exist). This could happen before, if no more valid server are in server_load. Now it could also happen if no servers with a required tag are present, or no untagged servers when falling back from an optional tag. Merging https://github.com/blindsidenetworks/scalelite/pull/1050 would change that such that an existing meeting will be selected even if find_available would fail (for any reason).

## TODO:

- [x] Merge https://github.com/blindsidenetworks/scalelite/pull/1052
- [x] Support sync via YAML server list
- [x] Support SL Server API
- [x] Full RSpec/Rails test coverage
- [x] Docs

## Testing Steps
<!--- Please describe in detail how to test your changes. -->
For the already added code I have added corresponding automated tests. The code is also already used in actual **production deployment**, but in combination with https://github.com/blindsidenetworks/scalelite/pull/1050 and https://github.com/blindsidenetworks/scalelite/pull/1052. 

## Ideas for Greenlight
I imagine to have a per-role configuration of allowed tags, analogue to the allowed recording visibilities configuration. The difference would be however, that here we need a configurable list of possible tags, unlike the fixed/hardcoded list of possible recording visibilities.

## Other ideas
It turned out that one could also "abuse" this feature to achieve per-tenant server pools by enforcing a certain meta_server-tag via OVERRIDE_CREATE_PARAMS for each (or some) tenants. But I think it would be better to have this as an explicit feature and it could be implemented in a very similar way to tags, by allowing to set a list of tenant IDs for a server to restrict the usage to them. But I think I'll wait for a review on the current PRs before working on this.

## Merge with PR [1052](https://github.com/blindsidenetworks/scalelite/pull/1052)
After merging https://github.com/blindsidenetworks/scalelite/pull/1052, `find_available` in `app/models/server.rb` will look like this:
```
def self.find_available(tag_arg = nil)
    # Check if tag is required
    tag = tag_arg.presence
    tag_required = false
    if !tag.nil? && tag[-1] == '!'
        tag = tag[0..-2].presence # always returns String, if tag is String
        tag_required = true
    end

    # Find available&matching server with the lowest load
    with_connection do |redis|
      ids_loads = redis.zrange('server_load', 0, -1, with_scores: true)
      raise RecordNotFound.new("Could not find any available servers.", name, nil) if ids_loads.blank?
      if !tag.nil? && ids_loads.none? { |myid, _| redis.hget(key(myid), 'tag') == tag }
        raise RecordNotFound.new("Could not find any available servers with tag=#{tag}.", name, nil) if tag_required
        tag = nil # fall back to servers without tag
      end
      ids_loads = ids_loads.select { |myid, _| redis.hget(key(myid), 'tag') == tag }
      id, load, hash = ids_loads.each do |id, load|
        hash = redis.hgetall(key(id))
        break id, load, hash if hash.present?
      end
      raise RecordNotFound.new("Could not find any available servers.", name, id) if hash.blank?

      hash['id'] = id
      if hash['state'].present?
        hash['state'] = 'enabled' # all servers in server_load set are enabled
      else
        hash['enabled'] = true
      end
      hash['load'] = load
      hash['online'] = (hash['online'] == 'true')
      new.init_with_attributes(hash)
    end
  end
  ```