### PR TITLE
Improved handling of create API call

### DIFF
--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -299,6 +299,9 @@ class BigBlueButtonApiController < ApplicationController
       logger.info("The requested meeting #{params[:meetingID]} does not exist")
       raise MeetingNotFoundError
     end
+    logger.debug("Incrementing server #{server.id} load by 1")
+    server.increment_load(1)
+
     # Get list of params that should not be modified by join API call
     excluded_params = Rails.configuration.x.join_exclude_params
 

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -165,36 +165,33 @@ class BigBlueButtonApiController < ApplicationController
       server = meeting.server
       logger.debug("Found existing meeting #{params[:meetingID]} on BigBlueButton server #{server.id}.")
     rescue ApplicationRedisRecord::RecordNotFound
-      # Find available server to create meeting on
       begin
+        # Find available server and create meeting on it
         server = Server.find_available(params[:'meta_server-tag'])
+
+        # Create meeting in database
+        logger.debug("Creating meeting #{params[:meetingID]} in database.")
+        moderator_pwd = params[:moderatorPW].presence || SecureRandom.alphanumeric(8)
+        meeting = Meeting.find_or_create_with_server!(
+          params[:meetingID],
+          server,
+          moderator_pwd,
+          params[:voiceBridge],
+          @tenant&.id
+        )
+
+        # Update server if meeting (unexpectedly) already existed on a different server
+        server = meeting.server
+
+        logger.debug("Incrementing server #{server.id} load by 1")
+        server.increment_load(1)
       rescue ApplicationRedisRecord::RecordNotFound => e
         raise InternalError, e.message
       end
     end
 
-    # Create meeting in database
-    logger.debug("Creating meeting #{params[:meetingID]} in database.")
-
-    moderator_pwd = params[:moderatorPW].presence || SecureRandom.alphanumeric(8)
-    params[:moderatorPW] = moderator_pwd
-
-    meeting = Meeting.find_or_create_with_server!(
-      params[:meetingID],
-      server,
-      moderator_pwd,
-      params[:voiceBridge],
-      @tenant&.id
-    )
-
-    # Update with old server if meeting already existed in database
-    server = meeting.server
-
-    logger.debug("Incrementing server #{server.id} load by 1")
-    server.increment_load(1)
-
-    duration = params[:duration].to_i
-
+    params[:moderatorPW] = meeting.moderator_pw
+    params[:voiceBridge] = meeting.voice_bridge
     params[:'meta_tenant-id'] = @tenant.id if @tenant.present?
     if server.tag.present?
       params[:'meta_server-tag'] = server.tag
@@ -202,14 +199,14 @@ class BigBlueButtonApiController < ApplicationController
       params.delete(:'meta_server-tag')
     end
 
+    duration = params[:duration].to_i
+
     # Set/Overite duration if MAX_MEETING_DURATION is set and it's greater than params[:duration] (if passed)
     if !Rails.configuration.x.max_meeting_duration.zero? &&
        (duration.zero? || duration > Rails.configuration.x.max_meeting_duration)
       logger.debug("Setting duration to #{Rails.configuration.x.max_meeting_duration}")
       params[:duration] = Rails.configuration.x.max_meeting_duration
     end
-
-    params[:voiceBridge] = meeting.voice_bridge
 
     if @tenant&.lrs_endpoint.present?
       lrs_payload = LrsPayloadService.new(tenant: @tenant, secret: server.secret).call


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

During work on https://github.com/blindsidenetworks/scalelite/pull/1049, it turned out the handling of the create API call could use some improvements. These are especially useful in the context of the mentioned PR, but are independent of it.

## Description
Changes:
1) In bigbluebutton_api_controller.rb, begin with checking whether the meeting is already running and only when nothing is found, continue with find_available servers and meeting find_or_create_with_server. When an existing meeting is found, use the returned meeting information directly, instead of the same information that would have been returned from find_or_create_with_server.
This is mostly an improvement in terms of logic (e.g. allowing for 2) ) and also a performance improvement for the create call (which frontends may repeat before every single join call). This may be slightly more relevant in the context of  https://github.com/blindsidenetworks/scalelite/pull/1049, where the find_available routine becomes slightly more expensive.
2) Only increment server_load if no meeting was found in 1), i.e. when a new meeting is actually created. To compensate, increment server_load on every join call. I think the previous implementation did rely on frontends always pairing join calls with a create call, to adjust the preliminary load values. In any case, the poller will take care of proper load values after a while.

## Testing Steps
Existing automated tests + used in actual **production** deployment, in combination with https://github.com/blindsidenetworks/scalelite/pull/1049 .

## Notes
- A notable change in behavior is that before this patch, a create call would always fail if Server.find_available threw an error, even if the meeting would already exist in the database. With this patch it would indeed try to forward the create call to the corresponding server, even if the said server is not registered as available anymore. Before this patch it would do exactly the same in the end, but only if *any* other server was found in find_available, from which it then would fall back to the registered server for the meeting.