### PR TITLE
Improvements to loop in server find_available

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -278,11 +278,9 @@ class Server < ApplicationRedisRecord
   # Find the server with the lowest load (for creating a new meeting)
   def self.find_available
     with_connection do |redis|
-      id, load, hash = 5.times do
-        ids_loads = redis.zrange('server_load', 0, 0, with_scores: true)
-        raise RecordNotFound.new("Couldn't find available Server", name, nil) if ids_loads.blank?
-
-        id, load = ids_loads.first
+      ids_loads = redis.zrange('server_load', 0, -1, with_scores: true)
+      raise RecordNotFound.new("Couldn't find available Server", name, nil) if ids_loads.blank?
+      id, load, hash = ids_loads.each do |id, load|
         hash = redis.hgetall(key(id))
         break id, load, hash if hash.present?
       end


### PR DESCRIPTION
In server find_available, get server_load set only once and iterate through it until server with valid hash is found.

<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
In server find_available, only retrieve the server_load via zrange once (but get the whole range instead of only first element) and iterate through it until a valid server is found. In my opinion this is a much more sane approach than the (kinda arbitrary) 5-times loop which always used the first element in the repeatedly obtained zrange. Furthermore, this would slim down the implementation in https://github.com/blindsidenetworks/scalelite/pull/1049.

## Testing Steps
Existing automated tests + testing in actual deployment.

## Notes
- PR https://github.com/blindsidenetworks/scalelite/pull/1049 would be affected and need appropriate changes.