### PR TITLE
Prevent column line wrapping in output of rake status task

### DIFF
--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -35,7 +35,7 @@ server.largest_meeting, server.videos, server.load)
     t.add_column('LOAD', &:load)
   end
 
-  puts table.pack
+  puts table.pack(max_table_width: nil)
 end
 
 def status_with_state(state)


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

This PR prevent line wrapping within columns of the table outputted by the `rake status` task.

## Description
The Tabulo gem used to produce the table in the `rake status` task uses per default the terminal width as maximum table width when calling .pack() on the table before printing it: https://github.com/matt-harvey/tabulo#max-table-width
When the table content does not fit within this width, the gem will resort to line wrapping within columns to make the table fit. While this (very arguably) may be visually pleasing, it can unexpectedly break any kind of commands or scripts used on the output of `rake status`.

To prevent this behavior, `.pack()` is now called as follows: `.pack(max_table_width: nil)`.

## Fixed issues
https://github.com/blindsidenetworks/scalelite/issues/1020
