### PR TITLE
Remove '.sh' from scalelite_prune_recordings such that it actually gets executed by cron

### DIFF
--- a/bigbluebutton/README.md
+++ b/bigbluebutton/README.md
@@ -61,3 +61,7 @@ Finally (after switching back to root), set the `spool_dir` setting in `scalelit
 ### Other configurations
 
 If you need to customize the rsync command (for example, to pass the `--rsh` option to set up a tunnel), you can add extra rsync command line arguments via the `extra_rsync_opts` array in `scalelite.yml`.
+
+### Recording cleanup cronjob
+
+Copy the script `scalelite_prune_recordings` to `/etc/cron.daily` on the BBB server, to periodically clean up the local files of recordings that have been transferred to Scalelite. You may adjust the variables MAXAGE and EVENTS_MAXAGE to the number of days you would like to keep the local files on the BBB server.

--- a/bigbluebutton/scalelite_prune_recordings
+++ b/bigbluebutton/scalelite_prune_recordings
@@ -1,6 +1,6 @@
-#!/bin/bash 
+#!/bin/bash
 
-# Place this file in /etc/cron.daily
+# Place this file in /etc/cron.daily and make sure it is executable
 #
 
 # Delete sent recording after 4 days


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

Having a dot in a filename prevents execution by cron when put under /etc/cron directories. Therefore, this PR removes the `.sh`extension from the filename. Also, a short README section is added.

See https://github.com/blindsidenetworks/scalelite/issues/1044 for further details regarding the cron behavior.

## Fixed issues
https://github.com/blindsidenetworks/scalelite/issues/1044

## Note
This will break any automated build scripts relying on the old filename to download the script from the repo. However, I assume in many cases they didn't rename the file and thus the script didn't do anything anyway.
