### PR TITLE
Fixes & improvements for servers:yaml rake task

### DIFF
--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -177,7 +177,7 @@ class ServerSync
         "enabled" => server.enabled?,
       }
       if verbose
-        info["state"] = server.state.presence || server.enabled ? 'enabled' : 'disabled'
+        info["state"] = server.state.presence || server.enabled? ? 'enabled' : 'disabled'
         info["load"] = server.load.presence || -1.0
         info["online"] = server.online
       end

--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -174,7 +174,7 @@ class ServerSync
         "url" => server.url,
         "secret" => server.secret,
         "load_multiplier" => server.load_multiplier.to_f || 1.0,
-        "enabled" => server.enabled,
+        "enabled" => server.enabled?,
       }
       if verbose
         info["state"] = server.state.presence || server.enabled ? 'enabled' : 'disabled'

--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -177,7 +177,7 @@ class ServerSync
         "enabled" => server.enabled?,
       }
       if verbose
-        info["state"] = server.state.presence || server.enabled? ? 'enabled' : 'disabled'
+        info["state"] = server.state.presence || (server.enabled? ? 'enabled' : 'disabled')
         info["load"] = server.load.presence || -1.0
         info["online"] = server.online
       end

--- a/lib/server_sync.rb
+++ b/lib/server_sync.rb
@@ -171,15 +171,15 @@ class ServerSync
   def self.dump(verbose)
     Server.all.to_h do |server|
       info = {
-        url: server.url,
-        secret: server.secret,
-        load_multiplier: server.load_multiplier.to_f || 1.0,
-        enabled: server.enabled,
+        "url" => server.url,
+        "secret" => server.secret,
+        "load_multiplier" => server.load_multiplier.to_f || 1.0,
+        "enabled" => server.enabled,
       }
       if verbose
-        info[:state] = server.state.presence || server.enabled ? 'enabled' : 'disabled'
-        info[:load] = server.load.presence || -1.0
-        info[:online] = server.online
+        info["state"] = server.state.presence || server.enabled ? 'enabled' : 'disabled'
+        info["load"] = server.load.presence || -1.0
+        info["online"] = server.online
       end
       [server.id, info]
     end

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -200,7 +200,7 @@ namespace :servers do
 
   desc 'Return a yaml compatible with servers:sync'
   task :yaml, [:verbose] => :environment do |_t, args|
-    puts({ servers: ServerSync.dump(!!args.verbose) }.to_yaml)
+    puts({ "servers" => ServerSync.dump(!!args.verbose) }.to_yaml)
   end
 
   desc('List all meetings running in specific BigBlueButton servers')


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

Fixes multiple issues with the `rake servers:yaml` task.

## Description
The `rake servers:yaml` task had 3-4 bugs:
1) [Output of rake servers:yaml is incompatible to servers:sync ](https://github.com/blindsidenetworks/scalelite/issues/1057) This could in principle be fixed by specifying certain options in the YAML.safe_load call, but in my opinion it makes more sense to use strings for the keys. It is more human write-/readable and YAML.safe_load will work "out of the box".  This PR converts all the keys to strings.
2) [The value of "enabled" was always empty](https://github.com/blindsidenetworks/scalelite/issues/1024), because `servers.enabled` does not exist. It must be `servers.enabled?`, which is fixed by the PR.
3) The same mistake of 2) was also present in the logic behind the "state" value in the verbose servers:yaml output. This is also fixed.
4) In the line referenced by 3) there was another error w.r.t. operator associativity, which ultimately prevented output of the state 'cordoned'.

## Testing Steps
Tested multiple configurations by dumping the YAML and then syncing it (after changing some value in the YAML or in the setup).

## Before/After
Before:
```
bash-5.1$ rake servers:yaml
---
:servers:
  bbb-xyz-1:
    :url: https://bbb-xyz-1/bigbluebutton/api
    :secret: xyz-1
    :load_multiplier: 1.0
    :enabled:
  bbb-xyz-2:
    :url: https://bbb-xyz-2/bigbluebutton/api
    :secret: xyz-2
    :load_multiplier: 1.0
    :enabled:
```

After:
```
bash-5.1$ rake servers:yaml
---
servers:
  bbb-xyz-1:
    url: https://bbb-xyz-1/bigbluebutton/api
    secret: xyz-1
    load_multiplier: 1.0
    enabled: true
  bbb-xyz-2:
    url: https://bbb-xyz-2/bigbluebutton/api
    secret: xyz-2
    load_multiplier: 1.0
    enabled: false
```

## Fixed Issues
Fixes https://github.com/blindsidenetworks/scalelite/issues/1057
Fixes https://github.com/blindsidenetworks/scalelite/issues/1024

## Other notes
Has a trivial conflict with https://github.com/blindsidenetworks/scalelite/pull/1049