### PR TITLE
Fix protected recordings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@ RUN apk add --no-cache nginx tini gettext \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 RUN rm /etc/nginx/http.d/default.conf
-COPY --from=bbb-playback /usr/share/bigbluebutton/nginx/ /etc/bigbluebutton/nginx/
 COPY --from=bbb-playback /var/bigbluebutton/playback /var/bigbluebutton/playback/
 COPY nginx/start /etc/nginx/start
 COPY nginx/dhparam.pem /etc/nginx/dhparam.pem
 COPY nginx/conf.d /etc/nginx/http.d/
+COPY nginx/playback /etc/bigbluebutton/nginx/
 EXPOSE 80
 EXPOSE 443
 ENV NGINX_HOSTNAME=localhost

--- a/dockerfiles/v1/focal260-alpine
+++ b/dockerfiles/v1/focal260-alpine
@@ -25,11 +25,11 @@ RUN apk add --no-cache nginx tini gettext \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 RUN rm /etc/nginx/http.d/default.conf
-COPY --from=bbb-playback /usr/share/bigbluebutton/nginx/ /etc/bigbluebutton/nginx/
 COPY --from=bbb-playback /var/bigbluebutton/playback /var/bigbluebutton/playback/
 COPY nginx/start /etc/nginx/start
 COPY nginx/dhparam.pem /etc/nginx/dhparam.pem
 COPY nginx/conf.d /etc/nginx/http.d/
+COPY nginx/playback /etc/bigbluebutton/nginx/
 EXPOSE 80
 EXPOSE 443
 ENV NGINX_HOSTNAME=localhost

--- a/dockerfiles/v1/focal260-amazonlinux
+++ b/dockerfiles/v1/focal260-amazonlinux
@@ -36,11 +36,11 @@ RUN yum install yum-utils -y
 RUN yum install nginx -y
 RUN ln -sf /dev/stdout /var/log/nginx/access.log
 RUN ln -sf /dev/stderr /var/log/nginx/error.log
-COPY --from=bbb-playback /usr/share/bigbluebutton/nginx/ /etc/bigbluebutton/nginx/
 COPY --from=bbb-playback /var/bigbluebutton/playback /var/bigbluebutton/playback/
 COPY nginx/start /etc/nginx/start
 COPY nginx/dhparam.pem /etc/nginx/dhparam.pem
 COPY nginx/conf.d /etc/nginx/http.d/
+COPY nginx/playback /etc/bigbluebutton/nginx/
 EXPOSE 80
 EXPOSE 443
 ENV NGINX_HOSTNAME=localhost

--- a/nginx/playback/playback.nginx
+++ b/nginx/playback/playback.nginx
@@ -1,0 +1,4 @@
+location /playback/presentation/2.3 {
+  root /var/bigbluebutton;
+  try_files $uri /playback/presentation/2.3/index.html;
+}

--- a/nginx/playback/presentation-video.nginx
+++ b/nginx/playback/presentation-video.nginx
@@ -1,0 +1,4 @@
+location ~ "/playback/video/(.*)$" {
+	return 307 /video/$1;
+}
+

--- a/nginx/playback/presentation.nginx
+++ b/nginx/playback/presentation.nginx
@@ -1,0 +1,12 @@
+location /playback/presentation/playback.html {
+        return 301 /playback/presentation/0.81/playback.html?$query_string;
+        # If you have recordings from 0.9.0 beta versions and are sure
+        # that you will never want to play recordings made with
+        # BigBlueButton 0.81, comment the line above and uncomment the
+        # following line:
+        #return 301 /playback/presentation/0.9.0/playback.html?$query_string;
+}
+
+location /playback/presentation/2.0/playback.html {
+        return 301 /playback/presentation/2.3/$arg_meetingId?$query_string;
+}

--- a/nginx/playback/recording-screenshare.nginx
+++ b/nginx/playback/recording-screenshare.nginx
@@ -1,0 +1,3 @@
+location ~ "/recording/screenshare/(.*)$" {
+        return 307 /screenshare/$1;
+}


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the protected recordings feature for all formats.

## Description
<!--- Describe your changes in detail -->
Protected recordings have been broken, i.e. unprotected paths were served by nginx, since at least SL v1.5. This has been reported in several issues.
The changes to nginx locations for presentation and video formats were originally proposed by @schrd in https://github.com/blindsidenetworks/scalelite/issues/983#issuecomment-1636724884

## Testing Steps
1) Generate a recording with all formats
2) transfer them to SL with protected recordings enabled
3) access them by clicking a format button in GL3
4) copy the (unprotected) recording URL from your browser into a different browser or private window
5) verify that you can't access the recording without token or cookie

~~**only the screenshare format is untested (of which I'm not sure if it actually works in any capacity at all), but it should behave just like the video format**~~
EDIT: Screenshare format tested and works as well

## Fixed issues
https://github.com/blindsidenetworks/scalelite/issues/983
https://github.com/blindsidenetworks/scalelite/issues/1008
https://github.com/blindsidenetworks/scalelite/issues/1046

I think it also fixes this: https://github.com/blindsidenetworks/scalelite/issues/880
Because previously I was not able to use "screenshare" recordings with Scalelite at all, see issue.
