### PR TITLE
[Mod] Serve formats without player as downloadable attachments

### DIFF
--- a/app/controllers/playback_controller.rb
+++ b/app/controllers/playback_controller.rb
@@ -96,6 +96,7 @@ class PlaybackController < ApplicationController
     resource_path = request.original_fullpath
     static_resource_path = "/static-resource#{resource_path}"
     response.headers['X-Accel-Redirect'] = static_resource_path
+    response.headers['Content-Disposition'] = "attachment" unless %w[presentation video screenshare].include?(@playback_format.format)
     head(:ok)
   end
 


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->
This PR sets the Content-Disposition header for all formats without player, e.g. all formats except presentation, video and screenshare, to make them get downloaded to the device instead of playing in the browser. The header is purposefully *not* set via nginx locations, to preserve recording protection (if configured).

## Description
This PR was originally part of https://github.com/blindsidenetworks/scalelite/pull/1083 , arising from a confusion on my end. I was thinking that formats like podcast have the Content-disposition header set to attachment by default from the bbb-playback package, but in fact that was just a specialty that I have introduced to our deployment due to user requests to make certain formats more easily downloadable (we also have a "download" version of the video format).

There are certainly arguments to be made for both variants, i.e. playback in the browser vs. download file, and the default from bbb-playback is the former for all formats, so I'm leaving this PR just as a mod example on how to achieve a different behavior.
