### PR TITLE
Support for semicolon-separated list of tags on create calls

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -294,7 +294,7 @@ class Server < ApplicationRedisRecord
         tags_arg = tags_arg[0..-2].presence # always returns String, if tag is String
         tags_required = true unless tags_arg.nil?
     end
-    tags = tags_arg&.split(',')
+    tags = tags_arg&.split(';')
 
     # Find available&matching server with the lowest load
     with_connection do |redis|

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -307,6 +307,7 @@ class Server < ApplicationRedisRecord
         tags.each do |tag|
           ids_loads_tagged.concat ids_loads.select { |myid, _| redis.hget(key(myid), 'tag') == tag }
         end
+        ids_loads_tagged.sort_by { |id_load| id_load[1] }
         if ids_loads_tagged.blank?
           raise BBBErrors::ServerTagUnavailableError, tags_arg if tags_required
           tags = nil # fall back to servers without tag

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -305,7 +305,7 @@ class Server < ApplicationRedisRecord
       unless tags.nil?
         ids_loads_tagged = []
         tags.each do |tag|
-          ids_loads_tagged.concat ids_loads.select { |myid, _| redis.hget(key(myid), 'tag') == tag }
+          ids_loads_tagged.concat ids_loads.select { |myid, _| (redis.hget(key(myid), 'tag') || "none") == tag }
         end
         ids_loads_tagged.sort_by! { |id_load| id_load[1] }
       end

--- a/docs/tags-README.md
+++ b/docs/tags-README.md
@@ -14,7 +14,7 @@ This works for all supported ways of adding servers: Per `rake servers:add` task
 
 A create API call using this feature is supposed to work as follows:
 
-1) When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag parameter with a string value. The string can be a single tag or a comma-separated list of tags and may additionally contain a '!' as last character. It will be handled as follows:
+1) When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag parameter with a string value. The string can be a single tag or a semicolon-separated list of tags and may additionally contain a '!' as last character. It will be handled as follows:
 2) If the last character of meta_server-tag is not a '!', the tags will will be intepreted as *optional*. The meeting will be created on the least loaded server with a tag matching one of the passed tags (the special tag 'none' will match untagged servers), if any is available, or on the least loaded untagged server otherwise.
 3) If the last character of meta_server-tag is a '!', this character will be stripped and the remaining tags will be interpreted as *required*. The meeting will be created on the least loaded server with a tag matching one of the passed tags (the special tag 'none' will match untagged servers) or *fail* to be created (with a specific error message), if no matching server is available.
 
@@ -35,7 +35,7 @@ HOSTNAME   STATE   STATUS  MEETINGS  USERS  LARGEST MEETING  VIDEOS  LOAD   BBB 
 Now, consider the following examples of `meta_server-tag` parameters:
 - Passing `meta_server-tag=` or `meta_server-tag=!` or omitting the parameter altogether are all equivalent and will place the meeting on `bbb-3` (least loaded untagged).
 - Passing `meta_server-tag=test` or `meta_server-tag=test!` will place the meeting on `bbb-1` (the only match).
-- Passing `meta_server-tag=test,test2` or `meta_server-tag=test,test2!` will place the meeting on `bbb-4` (least loaded match).
+- Passing `meta_server-tag=test;test2` or `meta_server-tag=test;test2!` will place the meeting on `bbb-4` (least loaded match).
 - Passing `meta_server-tag=none` or `meta_server-tag=none!` will place the meeting on `bbb-3` ) (least loaded match).
 - Passing `meta_server-tag=test3` will place the meeting on `bbb-3` (fallback to least loaded untagged).
 - Passing `meta_server-tag=test3!` will place the meeting on `bbb-3` (fallback to least loaded untagged).

--- a/docs/tags-README.md
+++ b/docs/tags-README.md
@@ -14,9 +14,28 @@ This works for all supported ways of adding servers: Per `rake servers:add` task
 
 A create API call with a meta feature is supposed to work as follows:
 
-1) When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag string as parameter. If passed, it will be handled as follows:
-2) If the last character of meta_server-tag is not a '!', the tag will will be intepreted as *optional*. The meeting will be created on the lowest load server with the corresponding tag, if any is available, or on the lowest load untagged (i.e. tag == nil) server otherwise.
-3) If the last character of meta_server-tag is a '!', this character will be stripped and the remaining tag will be interpreted as *required*. The meeting will be created on the lowest load server with the corresponding tag or fail to be created (with specific error message), if no matching server is available.
+1) When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag parameter with a string value. The string can be a single tag or a comma-separated list of tags and may additionally contain a '!' as last character. It will be handled as follows:
+2) If the last character of meta_server-tag is not a '!', the tags will will be intepreted as *optional*. The meeting will be created on the least loaded server with a tag matching one of the passed tags (the special tag 'none' will match untagged servers), if any is available, or on the least loaded untagged server otherwise.
+3) If the last character of meta_server-tag is a '!', this character will be stripped and the remaining tags will be interpreted as *required*. The meeting will be created on the least loaded server with a tag matching one of the passed tags (the special tag 'none' will match untagged servers) or *fail* to be created (with a specific error message), if no matching server is available.
 
 NOTE: Create calls without or with ''/'!' as meta_server-tag will only match untagged servers. So, for a frontend unaware of the feature, SL will behave as previously if a pool of untagged ("default") servers is maintained. It is recommended to always add your default servers as untagged servers.
 
+### Examples
+
+Consider the following setup:
+`$ bundle exec rake status`
+```
+HOSTNAME   STATE   STATUS  MEETINGS  USERS  LARGEST MEETING  VIDEOS  LOAD   BBB VERSION   TAG  
+ bbb-1    enabled  online  1         2      2                0        3.0      3.0.0      test
+ bbb-2    enabled  online  1         1      1                0        2.0      3.0.0
+ bbb-3    enabled  online  0         0      0                0        0.0      3.0.0 
+ bbb-4    enabled  online  1         1      1                0        2.0      3.0.0      test2
+ ```
+
+Now, consider the following examples of `meta_server-tag` parameters:
+- Passing `meta_server-tag=` or `meta_server-tag=!` or omitting the parameter altogether are all equivalent and will place the meeting on `bbb-3` (least loaded untagged).
+- Passing `meta_server-tag=test` or `meta_server-tag=test!` will place the meeting on `bbb-1` (the only match).
+- Passing `meta_server-tag=test,test2` or `meta_server-tag=test,test2!` will place the meeting on `bbb-4` (least loaded match).
+- Passing `meta_server-tag=none` or `meta_server-tag=none!` will place the meeting on `bbb-3` ) (least loaded match).
+- Passing `meta_server-tag=test3` will place the meeting on `bbb-3` (fallback to least loaded untagged).
+- Passing `meta_server-tag=test3!` will place the meeting on `bbb-3` (fallback to least loaded untagged).

--- a/docs/tags-README.md
+++ b/docs/tags-README.md
@@ -12,7 +12,7 @@ This works for all supported ways of adding servers: Per `rake servers:add` task
 
 ## Create call with server-tag metaparameter
 
-A create API call with a meta feature is supposed to work as follows:
+A create API call using this feature is supposed to work as follows:
 
 1) When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag parameter with a string value. The string can be a single tag or a comma-separated list of tags and may additionally contain a '!' as last character. It will be handled as follows:
 2) If the last character of meta_server-tag is not a '!', the tags will will be intepreted as *optional*. The meeting will be created on the least loaded server with a tag matching one of the passed tags (the special tag 'none' will match untagged servers), if any is available, or on the least loaded untagged server otherwise.

--- a/spec/models/server_spec.rb
+++ b/spec/models/server_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe Server, redis: true do
       end
 
       context 'and optional tag list argument' do
-        let(:server) { described_class.find_available('test-tag,test-tag2') }
+        let(:server) { described_class.find_available('test-tag;test-tag2') }
 
         it 'returns matching tagged server with lowest load' do
           expect(server.id).to eq 'test-5'
@@ -428,7 +428,7 @@ RSpec.describe Server, redis: true do
       end
 
       context 'and required tag list argument' do
-        let(:server) { described_class.find_available('test-tag,test-tag2!') }
+        let(:server) { described_class.find_available('test-tag;test-tag2!') }
 
         it 'returns matching tagged server with lowest load' do
           expect(server.id).to eq 'test-5'

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -243,7 +243,7 @@ class ServerTest < ActiveSupport::TestCase
     end
   end
 
-  test 'Server find_available without or with empty tag returns untagged server with lowest load' do
+  test 'Server find_available without or with empty tag or with none tag returns untagged server with lowest load' do
     RedisStore.with_connection do |redis|
       redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
                                           tag: 'test-tag', enabled: 'true')
@@ -275,6 +275,12 @@ class ServerTest < ActiveSupport::TestCase
     assert_equal('test-3', server.id)
 
     server = Server.find_available('!')
+    assert_equal('test-3', server.id)
+
+    server = Server.find_available('none')
+    assert_equal('test-3', server.id)
+
+    server = Server.find_available('none!')
     assert_equal('test-3', server.id)
   end
 
@@ -314,6 +320,44 @@ class ServerTest < ActiveSupport::TestCase
     server = Server.find_available('test-tag!')
     assert_equal('test-3', server.id)
     assert_equal('test-tag', server.tag)
+  end
+
+  test 'Server find_available with multiple tag arguments returns matching tagged server with lowest load' do
+    RedisStore.with_connection do |redis|
+      redis.mapped_hmset('server:test-1', url: 'https://test-1.example.com/bigbluebutton/api', secret: 'test-1-secret',
+                                          enabled: 'true')
+      redis.sadd?('servers', 'test-1')
+      redis.sadd?('server_enabled', 'test-1')
+      redis.zadd('server_load', 1, 'test-1')
+      redis.mapped_hmset('server:test-2', url: 'https://test-2.example.com/bigbluebutton/api', secret: 'test-2-secret',
+                                          tag: 'test-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-2')
+      redis.sadd?('server_enabled', 'test-2')
+      redis.zadd('server_load', 3, 'test-2')
+      redis.mapped_hmset('server:test-3', url: 'https://test-3.example.com/bigbluebutton/api', secret: 'test-3-secret',
+                                          tag: 'test-tag2', enabled: 'true')
+      redis.sadd?('servers', 'test-3')
+      redis.sadd?('server_enabled', 'test-3')
+      redis.zadd('server_load', 2, 'test-3')
+      redis.mapped_hmset('server:test-4', url: 'https://test-4.example.com/bigbluebutton/api', secret: 'test-4-secret',
+                                          tag: 'wrong-tag', enabled: 'true')
+      redis.sadd?('servers', 'test-4')
+      redis.sadd?('server_enabled', 'test-4')
+      redis.zadd('server_load', 1, 'test-4')
+    end
+
+    server = Server.find_available('test-tag,test-tag2')
+    assert_equal('test-3', server.id)
+    assert_equal('https://test-3.example.com/bigbluebutton/api', server.url)
+    assert_equal('test-3-secret', server.secret)
+    assert_equal('test-tag2', server.tag)
+    assert(server.enabled)
+    assert_nil(server.state)
+    assert_equal(2, server.load)
+
+    server = Server.find_available('test-tag,test-tag2!')
+    assert_equal('test-3', server.id)
+    assert_equal('test-tag2', server.tag)
   end
 
   test 'Server find_available with optional tag returns untagged server with lowest load if no matching tagged server available' do

--- a/test/models/server_test.rb
+++ b/test/models/server_test.rb
@@ -346,7 +346,7 @@ class ServerTest < ActiveSupport::TestCase
       redis.zadd('server_load', 1, 'test-4')
     end
 
-    server = Server.find_available('test-tag,test-tag2')
+    server = Server.find_available('test-tag;test-tag2')
     assert_equal('test-3', server.id)
     assert_equal('https://test-3.example.com/bigbluebutton/api', server.url)
     assert_equal('test-3-secret', server.secret)
@@ -355,7 +355,7 @@ class ServerTest < ActiveSupport::TestCase
     assert_nil(server.state)
     assert_equal(2, server.load)
 
-    server = Server.find_available('test-tag,test-tag2!')
+    server = Server.find_available('test-tag;test-tag2!')
     assert_equal('test-3', server.id)
     assert_equal('test-tag2', server.tag)
   end


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

This PR enables support for semicolon-separated lists of tags as meta_server-tag argument in create calls, which then matches all servers with any of the tags in the list. It also introduces `none` as a special tag to explicitly reference untagged servers.

## Description
The following is a part of the updated documentation and describes how the feature works now:

A create API call using this feature is supposed to work as follows:

1) When making a "create" API call towards Scalelite, you can optionally pass a meta_server-tag parameter with a string value. The string can be a single tag or a semicolon-separated list of tags and may additionally contain a '!' as last character. It will be handled as follows:
2) If the last character of meta_server-tag is not a '!', the tags will will be intepreted as *optional*. The meeting will be created on the least loaded server with a tag matching one of the passed tags (the special tag 'none' will match untagged servers), if any is available, or on the least loaded untagged server otherwise.
3) If the last character of meta_server-tag is a '!', this character will be stripped and the remaining tags will be interpreted as *required*. The meeting will be created on the least loaded server with a tag matching one of the passed tags (the special tag 'none' will match untagged servers) or *fail* to be created (with a specific error message), if no matching server is available.

NOTE: Create calls without or with ''/'!' as meta_server-tag will only match untagged servers. So, for a frontend unaware of the feature, SL will behave as previously if a pool of untagged ("default") servers is maintained. It is recommended to always add your default servers as untagged servers.

### Examples

Consider the following setup:
`$ bundle exec rake status`
```
HOSTNAME   STATE   STATUS  MEETINGS  USERS  LARGEST MEETING  VIDEOS  LOAD   BBB VERSION   TAG  
 bbb-1    enabled  online  1         2      2                0        3.0      3.0.0      test
 bbb-2    enabled  online  1         1      1                0        2.0      3.0.0
 bbb-3    enabled  online  0         0      0                0        0.0      3.0.0 
 bbb-4    enabled  online  1         1      1                0        2.0      3.0.0      test2
 ```

Now, consider the following examples of `meta_server-tag` parameters:
- Passing `meta_server-tag=` or `meta_server-tag=!` or omitting the parameter altogether are all equivalent and will place the meeting on `bbb-3` (least loaded untagged).
- Passing `meta_server-tag=test` or `meta_server-tag=test!` will place the meeting on `bbb-1` (the only match).
- Passing `meta_server-tag=test;test2` or `meta_server-tag=test;test2!` will place the meeting on `bbb-4` (least loaded match).
- Passing `meta_server-tag=none` or `meta_server-tag=none!` will place the meeting on `bbb-3` ) (least loaded match).
- Passing `meta_server-tag=test3` will place the meeting on `bbb-3` (fallback to least loaded untagged).
- Passing `meta_server-tag=test3!` will place the meeting on `bbb-3` (fallback to least loaded untagged).

## Fixed issues
https://github.com/blindsidenetworks/scalelite/issues/1095
