### PR TITLE
Workaround for voice_bridge=99999 (test_voice_bridge) issue

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -203,6 +203,7 @@ class Meeting < ApplicationRedisRecord
   def self.allocate_voice_bridge(meeting_id, voice_bridge = nil)
     voice_bridge_len = Rails.configuration.x.voice_bridge_len
     use_external_voice_bridge = Rails.configuration.x.use_external_voice_bridge
+    test_voice_bridge = "99999" # default value in BBB, must be avoided
 
     # In order to make consistent random pin numbers, use the provided meeting as the seed. Ruby's 'Random' PRNG takes a 128bit
     # integer as seed. Create one from a truncated hash of the meeting id.
@@ -225,6 +226,7 @@ class Meeting < ApplicationRedisRecord
         end
         tries += 1
         logger.debug { "Trying to allocate voice bridge number #{voice_bridge}, try #{tries}" }
+        next if voice_bridge == test_voice_bridge # avoid special voice bridge number
 
         _created, allocated_meeting_id = redis.multi do |transaction|
           transaction.hsetnx('voice_bridges', voice_bridge, meeting_id)


### PR DESCRIPTION
## Description
For the solved problem, please refer to the extended description provided [here](https://github.com/blindsidenetworks/scalelite/issues/1120). This PR adds a hard-coded workaround (just rolling the dice again) for the default test_voice_bridge setting of 99999, which will match what is used in 99++% of BBB setups. In the rare case that this setting is changed to a non-default value, this workaround won't break anything (it will just avoid the particular voice bridge number of 99999).

I will open a separate issue to request an improved, configurable version of this workaround for the future (in case the underlying issue in BBB will not be fixed in the foreseeable future).

## Fixed issues
https://github.com/blindsidenetworks/scalelite/issues/1120
