### PR TITLE
Add a retry mechanism for recording ready notifier

### DIFF
--- a/spec/services/recording_ready_notifier_service_spec.rb
+++ b/spec/services/recording_ready_notifier_service_spec.rb
@@ -26,6 +26,29 @@ RSpec.describe RecordingReadyNotifierService, type: :service do
     expect(return_val).to be true
   end
 
+  it 'retries with different secrets if multiple secrets are set' do
+    stub_request(:post, url)
+      .to_return(
+        { status: 401, body: '', headers: {} }, # First secret fails
+        { status: 401, body: '', headers: {} }, # Second secret fails
+        { status: 200, body: '', headers: {} }  # Third secret succeeds
+      )
+
+    allow_any_instance_of(ApiHelper).to receive(:fetch_secrets).and_return(["secret1", "secret2", "secret3"])
+
+    allow(JWT).to receive(:encode).and_return('eyJhbGciOiJIUzI1NiJ9.eyJtZWV0aW5nX2lkIjoibWVldGluZzE5In0')
+
+    allow(Rails.logger).to receive(:info).and_call_original # Allow all other logger calls to pass through
+
+    expect(Rails.logger).to receive(:info).with("Callback HTTP request failed: 401  (code 401)").twice
+    expect(Rails.logger).to receive(:info).with("Recording notifier successful: #{recording.meeting_id} (code #{200})").once
+
+    return_val = described_class.execute(recording.id)
+
+    expect(return_val).to be true
+  end
+
+
   it 'returns false if recording ready notification fails' do
     stub_request(:post, url).to_timeout
 

--- a/spec/services/recording_ready_notifier_service_spec.rb
+++ b/spec/services/recording_ready_notifier_service_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe RecordingReadyNotifierService, type: :service do
     expect(return_val).to be true
   end
 
-
   it 'returns false if recording ready notification fails' do
     stub_request(:post, url).to_timeout
 

--- a/spec/services/recording_ready_notifier_service_spec.rb
+++ b/spec/services/recording_ready_notifier_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RecordingReadyNotifierService, type: :service do
         { status: 200, body: '', headers: {} }  # Third secret succeeds
       )
 
-    allow_any_instance_of(ApiHelper).to receive(:fetch_secrets).and_return(["secret1", "secret2", "secret3"])
+    allow_any_instance_of(ApiHelper).to receive(:fetch_secrets).and_return(%w[secret1 secret2 secret3])
 
     allow(JWT).to receive(:encode).and_return('eyJhbGciOiJIUzI1NiJ9.eyJtZWV0aW5nX2lkIjoibWVldGluZzE5In0')
 


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->
fixes #1029

## Description
<!--- Describe your changes in detail -->
Add a "retry" mechanism to loop through all of the loadbalancer secrets when sending the recording ready notification service

Greenlight PR: https://github.com/bigbluebutton/greenlight/pull/5972
## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
