### PR TITLE
Remove duplicate block in config/puma.rb

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -46,14 +46,6 @@ environment ENV.fetch("RAILS_ENV", "development")
 #
 workers ENV.fetch("WEB_CONCURRENCY", 0)
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-workers ENV.fetch("WEB_CONCURRENCY", 0)
-
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write


### PR DESCRIPTION
During merging of files in https://github.com/blindsidenetworks/scalelite/pull/1125 , a config block in `config/puma.rb` has accidentally been duplicated. This PR removes the duplication.