### PR TITLE
Consistent Ruby version in GitHub workflows / rubocop + Fix amazonlinux build

### DIFF
--- a/.github/workflows/ci.build.prerelease.yml
+++ b/.github/workflows/ci.build.prerelease.yml
@@ -1,5 +1,5 @@
 env:
-  RUBY_VERSION: 2.7.x
+  RUBY_VERSION: 3.3.6
 
 name: CI Build Pre-Release
 on:
@@ -12,7 +12,7 @@ jobs:
     env:
       DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
       DOCKER_BUILD_ENABLED: ${{ secrets.DOCKER_BUILD_ENABLED }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         if: contains(env.DOCKER_BUILD_ENABLED, 'true')

--- a/.github/workflows/ci.build.push.master.yml
+++ b/.github/workflows/ci.build.push.master.yml
@@ -1,5 +1,5 @@
 env:
-  RUBY_VERSION: 2.7.x
+  RUBY_VERSION: 3.3.6
 
 name: CI Build Push
 on:
@@ -15,7 +15,7 @@ jobs:
       DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
       DOCKER_BUILD_ENABLED: ${{ secrets.DOCKER_BUILD_ENABLED }}
       DOCKER_BUILD_ALTERNATE_ENABLED: ${{ secrets.DOCKER_BUILD_ALTERNATE_ENABLED }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check preconditions
         id: preconditions

--- a/.github/workflows/ci.build.push.yml
+++ b/.github/workflows/ci.build.push.yml
@@ -1,5 +1,5 @@
 env:
-  RUBY_VERSION: 2.7.x
+  RUBY_VERSION: 3.3.6
 
 name: CI Build Push
 on:
@@ -18,7 +18,7 @@ jobs:
       DOCKER_BUILD_ENABLED: ${{ secrets.DOCKER_BUILD_ENABLED }}
       DOCKER_BUILD_ALTERNATE_ENABLED: ${{ secrets.DOCKER_BUILD_ALTERNATE_ENABLED }}
       DOCKER_BUILD_ON_PUSH_DISABLED: ${{ secrets.DOCKER_BUILD_ON_PUSH_DISABLED }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check preconditions
         id: preconditions

--- a/.github/workflows/ci.build.release.yml
+++ b/.github/workflows/ci.build.release.yml
@@ -1,5 +1,5 @@
 env:
-  RUBY_VERSION: 2.7.x
+  RUBY_VERSION: 3.3.6
 
 name: CI Build Release
 on:
@@ -12,7 +12,7 @@ jobs:
     env:
       DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
       DOCKER_BUILD_ENABLED: ${{ secrets.DOCKER_BUILD_ENABLED }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         if: contains(env.DOCKER_BUILD_ENABLED, 'true')

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
   - 'vendor/**/*'
   - 'vendor/bundle/**/*'
   DisabledByDefault: false
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.3
 
   NewCops: enable
 
@@ -235,6 +235,9 @@ Style/OptionalBooleanParameter:
 
 Style/SlicingWithRange:
   Enabled: true
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
 
 RSpec/ContextWording:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '>= 3.0.0'
+ruby '>= 3.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 7.2'

--- a/app/controllers/concerns/cookie_same_site_compat.rb
+++ b/app/controllers/concerns/cookie_same_site_compat.rb
@@ -13,14 +13,14 @@ module CookieSameSiteCompat
 
   private
 
-  IOS_VERSION_REGEXP = %r{\(iP.+; CPU .*OS (\d+)[_\d]*.*\) AppleWebKit/}.freeze
-  MACOS_VERSION_REGEXP = %r{\(Macintosh;.*Mac OS X (\d+)_(\d+)[_\d]*.*\) AppleWebKit/}.freeze
-  SAFARI_REGEXP = %r{Version/.* Safari/}.freeze
-  CHROMIUM_BASED_REGEXP = /Chrom(?:e|ium)/.freeze
-  CHROMIUM_VERSION_REGEXP = %r{Chrom[^ /]+/(\d+)[.\d]* }.freeze
-  MAC_EMBEDDED_REGEXP = %r{^Mozilla/[.\d]+ \(Macintosh;.*Mac OS X [_\d]+\) AppleWebKit/[.\d]+ \(KHTML, like Gecko\)$}.freeze
-  UC_BROWSER_REGEXP = %r{UCBrowser/}.freeze
-  UC_BROWSER_VERSION_REGEXP = %r{UCBrowser/(\d+)\.(\d+)\.(\d+)[.\d]* }.freeze
+  IOS_VERSION_REGEXP = %r{\(iP.+; CPU .*OS (\d+)[_\d]*.*\) AppleWebKit/}
+  MACOS_VERSION_REGEXP = %r{\(Macintosh;.*Mac OS X (\d+)_(\d+)[_\d]*.*\) AppleWebKit/}
+  SAFARI_REGEXP = %r{Version/.* Safari/}
+  CHROMIUM_BASED_REGEXP = /Chrom(?:e|ium)/
+  CHROMIUM_VERSION_REGEXP = %r{Chrom[^ /]+/(\d+)[.\d]* }
+  MAC_EMBEDDED_REGEXP = %r{^Mozilla/[.\d]+ \(Macintosh;.*Mac OS X [_\d]+\) AppleWebKit/[.\d]+ \(KHTML, like Gecko\)$}
+  UC_BROWSER_REGEXP = %r{UCBrowser/}
+  UC_BROWSER_VERSION_REGEXP = %r{UCBrowser/(\d+)\.(\d+)\.(\d+)[.\d]* }
 
   def webkit_same_site_bug?(useragent)
     return true if ios_version?(12, useragent)

--- a/app/models/application_redis_record.rb
+++ b/app/models/application_redis_record.rb
@@ -146,8 +146,8 @@ class ApplicationRedisRecord
   end
   delegate :connection_pool, to: 'self.class'
 
-  def self.with_connection(&block)
-    RedisStore.with_connection(&block)
+  def self.with_connection(&)
+    RedisStore.with_connection(&)
   end
   delegate :with_connection, to: 'self.class'
 

--- a/dockerfiles/v1/focal260-amazonlinux
+++ b/dockerfiles/v1/focal260-amazonlinux
@@ -48,15 +48,24 @@ CMD [ "/etc/nginx/start", "-g", "daemon off;" ]
 
 FROM amazonlinux-base AS base
 # Install Node.js (needed for yarn)
-RUN yum -y install gcc-c++ make
+RUN yum -y install git gcc-c++ make libyaml-devel libffi-devel glibc-devel readline-devel openssl-devel
 RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
 RUN yum -y install nodejs
 # Install Ruby & Rails
 RUN curl -sL -o /etc/yum.repos.d/yarn.repo https://dl.yarnpkg.com/rpm/yarn.repo
-RUN amazon-linux-extras enable ruby3.0 postgresql14 \
-    && yum -y install git tar gzip yarn shared-mime-info libxslt zlib-devel sqlite-devel mariadb-devel libpq-devel ruby-devel rubygems-devel rubygem-bundler rubygem-io-console rubygem-irb rubygem-json rubygem-minitest rubygem-power_assert rubygem-rake rubygem-test-unit rubygem-bigdecimal
+RUN amazon-linux-extras enable postgresql14 \
+    && yum -y install tar gzip yarn shared-mime-info libxslt zlib-devel sqlite-devel mariadb-devel libpq-devel
+RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
+    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc && \
+    echo 'eval "$(rbenv init -)"' >> ~/.bashrc && \
+    git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build && \
+    ~/.rbenv/bin/rbenv install 3.3.6 && \
+    ~/.rbenv/bin/rbenv global 3.3.6 && \
+    ~/.rbenv/bin/rbenv rehash
+ENV PATH="/root/.rbenv/shims:/root/.rbenv/bin:$PATH"
 RUN yum -y install python3 python3-pip shadow-utils
-RUN gem install bundler -v '2.1.4'
+RUN gem install bundler -v '~> 2.5'
+
 RUN groupadd scalelite --gid 1000 && \
     useradd -u 1000 -d /srv/scalelite -g scalelite scalelite
 RUN groupadd scalelite-spool --gid 2000 && \

--- a/dockerfiles/v1/focal260-amazonlinux
+++ b/dockerfiles/v1/focal260-amazonlinux
@@ -1,4 +1,5 @@
 FROM amazonlinux:2.0.20240620.0 AS amazonlinux
+SHELL ["/bin/bash", "-c"]
 
 FROM ubuntu:20.04 AS bbb-playback
 ENV DEBIAN_FRONTEND=noninteractive
@@ -47,46 +48,45 @@ ENV NGINX_HOSTNAME=localhost
 CMD [ "/etc/nginx/start", "-g", "daemon off;" ]
 
 FROM amazonlinux-base AS base
-# Install Node.js (needed for yarn)
+# Install basic packages
 RUN yum -y install git gcc-c++ make libyaml-devel libffi-devel glibc-devel readline-devel openssl-devel
+# Install Node.js (needed for yarn)
 RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
 RUN yum -y install nodejs
-# Install Ruby & Rails
+# Install other packages
 RUN curl -sL -o /etc/yum.repos.d/yarn.repo https://dl.yarnpkg.com/rpm/yarn.repo
 RUN amazon-linux-extras enable postgresql14 \
-    && yum -y install tar gzip yarn shared-mime-info libxslt zlib-devel sqlite-devel mariadb-devel libpq-devel
-RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
-    echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc && \
-    echo 'eval "$(rbenv init -)"' >> ~/.bashrc && \
-    git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build && \
-    ~/.rbenv/bin/rbenv install 3.3.6 && \
-    ~/.rbenv/bin/rbenv global 3.3.6 && \
-    ~/.rbenv/bin/rbenv rehash
-ENV PATH="/root/.rbenv/shims:/root/.rbenv/bin:$PATH"
-RUN yum -y install python3 python3-pip shadow-utils
-RUN gem install bundler -v '~> 2.5'
-
+    && yum -y install tar gzip yarn shared-mime-info libxslt zlib-devel sqlite-devel mariadb-devel libpq-devel python3 python3-pip shadow-utils
+# Setup user scalelite
 RUN groupadd scalelite --gid 1000 && \
     useradd -u 1000 -d /srv/scalelite -g scalelite scalelite
 RUN groupadd scalelite-spool --gid 2000 && \
     usermod -a -G scalelite-spool scalelite
+USER scalelite:scalelite
+# Install Ruby
+RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv && \
+    git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build && \
+    ~/.rbenv/bin/rbenv install 3.3.6 && \
+    ~/.rbenv/bin/rbenv global 3.3.6 && \
+    ~/.rbenv/bin/rbenv rehash
+ENV PATH="~/.rbenv/shims:~/.rbenv/bin:$PATH"
+RUN echo 'export PATH="~/.rbenv/bin:$PATH"' >> ~/.bashrc && \
+    echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+RUN gem install bundler -v '~> 2.5'
 WORKDIR /srv/scalelite
 
 FROM base as builder
-RUN rm -rf nginx
-USER scalelite:scalelite
 COPY --chown=scalelite:scalelite Gemfile* ./
-RUN bundle --version
-RUN bundle config build.nokogiri --use-system-libraries
-RUN bundle config set --local deployment 'true'
-RUN bundle config set --local without 'development:test'
-RUN bundle install -j4
-RUN rm -rf vendor/bundle/ruby/*/cache
-RUN find vendor/bundle/ruby/*/gems/ \( -name '*.c' -o -name '*.o' \) -delete
+RUN source ~/.bashrc && bundle --version && \
+    bundle config build.nokogiri --use-system-libraries && \
+    bundle config set --local deployment 'true' && \
+    bundle config set --local without 'development:test' && \
+    bundle install -j4 && \
+    rm -rf vendor/bundle/ruby/*/cache && \
+    find vendor/bundle/ruby/*/gems/ \( -name '*.c' -o -name '*.o' \) -delete
 COPY --chown=scalelite:scalelite . ./
 
 FROM base AS application
-USER scalelite:scalelite
 ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=true
 COPY --from=builder --chown=scalelite:scalelite /srv/scalelite ./
 

--- a/lib/redis_store.rb
+++ b/lib/redis_store.rb
@@ -34,7 +34,7 @@ module RedisStore
     end
   end
 
-  def self.with_connection(&block)
-    connection_pool.with(&block)
+  def self.with_connection(&)
+    connection_pool.with(&)
   end
 end


### PR DESCRIPTION
Consistent Ruby version in Github workflows / rubocop (including trivial adaptions).

## Description
By working on GL3 I got remembered of the fact that the Ruby version is specified in more of the Github workflow files besides just the `ci.yml`, although the variable is not *obviously* used in any way in these files. Nevertheless, this PR makes the specified Ruby version consistent in these files. Also, the Ruby version target for Rubocop is adapted, including some trivial suggested changes.
The problem with the GitHub workflow files is also that there seems to be a lot of redundancy, but I'm not very familiar with the GitHub CI system since I'm generally using GitLab CI for test,build,push and thus won't touch that.

~~Another thing that apparently needs to be addressed is the whole amazonlinux build, which is currently failing due to Ruby being stuck on 3.0 there. I think the build needs to switch to a custom Ruby installation e.g. via rbenv and should soon be migrated from AL2 to AL2023 (for which I've read that support Ruby 3.3 is coming very soon or is already there).~~

EDIT: Now this PR also fixes the amazonlinux build, by using rbenv to install Ruby 3.3. The point of upgrading to AL2023 still stands. @paulseto , I have seen a PR from you regarding the amazonlinux build in the past. Would you be able and willing to work on this?