### PR TITLE
Add meeting expiry to redis to remove obsolete entries

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -23,6 +23,8 @@ class Meeting < ApplicationRedisRecord
   # @return [Integer] ID of the tenant.
   attr_accessor :tenant_id
 
+  DEFAULT_MEETING_TTL = 24 * 60 * 60 # 24 hours in seconds
+
   def voice_bridge=(value)
     raise ArgumentError, "Voice bridge cannot be updated once set" unless @voice_bridge.nil?
 
@@ -162,6 +164,7 @@ class Meeting < ApplicationRedisRecord
           transaction.hsetnx(meeting_key, 'voice_bridge', voice_bridge)
           transaction.hsetnx(meeting_key, 'tenant_id', tenant_id)
           transaction.hgetall(meeting_key)
+          transaction.expire(meeting_key, DEFAULT_MEETING_TTL)
           transaction.sadd?('meetings', id)
         end
 

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -198,6 +198,15 @@ RSpec.describe Meeting, :redis do
       end
     end
 
+    it 'sets the ttl of the meeting for 24 hours' do
+      server = Server.find('test-server-1')
+      described_class.find_or_create_with_server('Demo Meeting', server, 'mp')
+
+      RedisStore.with_connection do |redis|
+        expect(redis.ttl('meeting:Demo Meeting')).to eq(described_class::DEFAULT_MEETING_TTL)
+      end
+    end
+
     context 'atomic create (new meeting)' do
       before do
         RedisStore.with_connection do |redis|

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -220,9 +220,10 @@ RSpec.describe Meeting, :redis do
       end
 
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+      true_options = [1, true]
       loop do
         exists = RedisStore.with_connection { |r| r.exists?(key) }
-        break unless [1, true].include?(exists)
+        break unless true_options.include?(exists)
         break if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
         sleep 0.05
       end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -216,13 +216,13 @@ RSpec.describe Meeting, :redis do
       key = "meeting:Demo Meeting"
 
       RedisStore.with_connection do |redis|
-        expect(redis.exists?(key)).to be_truthy
+        expect(redis).to exist(key)
       end
 
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
       loop do
         exists = RedisStore.with_connection { |r| r.exists?(key) }
-        break unless exists == 1 || exists == true
+        break unless [1, true].include?(exists)
         break if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
         sleep 0.05
       end
@@ -231,7 +231,6 @@ RSpec.describe Meeting, :redis do
         expect(redis.exists?(key)).to be false
       end
     end
-
 
     context 'atomic create (new meeting)' do
       before do


### PR DESCRIPTION
<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

solves #1161 

## Description
<!--- Describe your changes in detail -->
As a temporary fix, add a 24 hour expiry to meetings to solve the issue with obsolete meetings.

Long term, the poller will likely need to be adapted to handle this

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
