### PR TITLE
fix: make rake update task untag server on explicitly empty tag argument

### DIFF
--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -66,7 +66,9 @@ namespace :servers do
       end
     end
     server.load_multiplier = tmp_load_multiplier
-    server.tag = args.tag.presence unless args.tag.nil?
+    # inspect the raw positional arguments to distinguish an omitted tag from an explicit untag
+    tag_arg = args.to_a[3]
+    server.tag = tag_arg.presence unless tag_arg.nil?
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound

--- a/spec/tasks/servers/servers_tasks_spec.rb
+++ b/spec/tasks/servers/servers_tasks_spec.rb
@@ -51,4 +51,26 @@ RSpec.describe 'servers tasks', type: :task do
       expect { task.invoke(verbose) }.to output(%r{url: https://example.com}).to_stdout
     end
   end
+
+  describe 'servers:update task' do
+    let(:task) { Rake::Task['servers:update'] }
+
+    it 'updates the tag when the fourth argument is non-empty' do
+      server = create(:server, tag: nil, load_multiplier: 1.0)
+      task.invoke(server.id, server.secret, '1.0', 'test-tag')
+      expect(Server.find(server.id).tag).to eq('test-tag')
+    end
+
+    it 'clears the tag when the fourth argument is an empty string' do
+      server = create(:server, tag: 'test-tag', load_multiplier: 1.0)
+      task.invoke(server.id, server.secret, '1.0', '')
+      expect(Server.find(server.id).tag).to be_nil
+    end
+
+    it 'keeps the existing tag when the fourth argument is omitted' do
+      server = create(:server, tag: 'test-tag', load_multiplier: 1.0)
+      task.invoke(server.id, server.secret, '1.0')
+      expect(Server.find(server.id).tag).to eq('test-tag')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1234

## Description

- preserve the current `servers:update` behavior when the optional `tag` argument is omitted
- allow `servers:update[id,secret,loadMultiplier,]` to remove an existing server tag, in accordance with documentation
- add task specs covering both explicit untagging and omitted-tag updates, as well as non-empty tag updates
